### PR TITLE
Add agency page and chat support

### DIFF
--- a/OrbusLanding/agency.html
+++ b/OrbusLanding/agency.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Orbas Agency - World Class Web Solutions</title>
-    <meta name="description" content="Professional agency offering whitelabel websites, mobile apps, AI automations and marketing solutions.">
+    <title>Orbas Agency - 24/7 World Class Web Solutions</title>
+    <meta name="description" content="Professional agency offering whitelabel websites, mobile apps, AI automations and marketing solutions with 24/7 support.">
 
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
@@ -70,13 +70,13 @@
             <div>
                 <div class="inline-flex items-center px-4 py-2 rounded-full text-sm font-medium bg-green-500/20 text-green-300 border border-green-400/30 mb-6">
                     <span class="mr-2">🚀</span>
-                    World Class Web Solutions
+                    24/7 World Class Web Solutions
                 </div>
                 <h1 class="text-4xl sm:text-5xl lg:text-5xl font-bold text-white mb-6 leading-tight">
                     Orbas Agency
                 </h1>
                 <p class="text-lg sm:text-xl text-gray-300 mb-10 leading-relaxed">
-                    Our specialists craft high-impact websites, mobile apps and automation tools to accelerate your business growth.
+                    Our specialists craft high-impact websites, mobile apps and automations to accelerate your growth. Chat with us any time—tell us your budget and we’ll make it work.
                 </p>
                 <a href="mailto:agency@orbas.io" class="inline-flex items-center justify-center px-8 py-4 bg-white/10 hover:bg-white/20 text-white font-semibold rounded-xl transition-all duration-200 shadow-lg hover:shadow-xl transform hover:-translate-y-1">
                     Contact Agency
@@ -116,6 +116,7 @@
                 <li class="flex"><span class="font-bold text-orbas-green mr-2">5.</span>Blockchain Development</li>
                 <li class="flex"><span class="font-bold text-orbas-green mr-2">6.</span>A.I. Automations</li>
                 <li class="flex"><span class="font-bold text-orbas-green mr-2">7.</span>Marketing Solutions</li>
+                <li class="flex"><span class="font-bold text-orbas-green mr-2">8.</span>24/7 Support & Maintenance</li>
             </ul>
         </div>
     </section>
@@ -141,8 +142,8 @@
                     <p class="text-2xl font-bold text-orbas-green">£10,000+</p>
                 </div>
             </div>
-            <p class="mt-8 text-gray-600">Please contact <a href="mailto:agency@orbas.io" class="text-orbas-blue underline">agency@orbas.io</a> for enquiries or open the chat bubble to ask us about our agency service.</p>
-            <p class="mt-4 text-gray-600">We also have work available for freelancers. Email <a href="mailto:support@orbas.io" class="text-orbas-blue underline">support@orbas.io</a> with the subject <strong>Agency Work</strong>, and include your CV, cover letter and hourly fees.</p>
+            <p class="mt-8 text-gray-600">Reach out at <a href="mailto:agency@orbas.io" class="text-orbas-blue underline">agency@orbas.io</a> or open the chat bubble. Let us know your budget—we’ll tailor a plan to meet it.</p>
+            <p class="mt-4 text-gray-600">We also have work available for freelancers. Email <a href="mailto:support@orbas.io" class="text-orbas-blue underline">support@orbas.io</a> with the subject <strong>Agency Work</strong> and include your CV, cover letter and hourly fees.</p>
         </div>
     </section>
 

--- a/OrbusLanding/agency.html
+++ b/OrbusLanding/agency.html
@@ -1,0 +1,263 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Orbas Agency - World Class Web Solutions</title>
+    <meta name="description" content="Professional agency offering whitelabel websites, mobile apps, AI automations and marketing solutions.">
+
+    <!-- Favicon -->
+    <link rel="icon" type="image/svg+xml" href="favicon.svg">
+    <link rel="alternate icon" href="favicon.svg">
+
+    <!-- Google Fonts - Poppins -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+
+    <!-- Tailwind CSS -->
+    <script src="https://cdn.tailwindcss.com"></script>
+
+    <!-- Custom Tailwind Config -->
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    fontFamily: {
+                        'poppins': ['Poppins', 'sans-serif']
+                    },
+                    colors: {
+                        'orbas-blue': '#3b82f6',
+                        'orbas-dark-blue': '#1e40af',
+                        'orbas-light-blue': '#60a5fa',
+                        'orbas-orange': '#f97316',
+                        'orbas-green': '#10b981',
+                        'orbas-purple': '#8b5cf6',
+                        'orbas-pink': '#ec4899',
+                        'orbas-cream': '#fef3c7',
+                    }
+                }
+            }
+        }
+    </script>
+</head>
+<body class="bg-white text-gray-900 font-poppins antialiased">
+    <!-- Header Navigation -->
+    <header class="bg-white border-b border-gray-200 sticky top-0 z-50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex justify-between items-center h-16">
+                <!-- Logo -->
+                <div class="flex items-center">
+                    <img src="attached_assets/orbas logo_1752425860914.png" alt="Orbas Logo" class="h-12 w-auto">
+                </div>
+
+                <!-- Navigation -->
+                <nav class="hidden md:flex space-x-8">
+                    <a href="index.html#about" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">About</a>
+                    <a href="index.html#platforms" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Platforms</a>
+                    <a href="agency.html" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Agency</a>
+                    <a href="index.html#contact" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Contact</a>
+                    <a href="privacy.html" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Privacy</a>
+                </nav>
+            </div>
+        </div>
+    </header>
+
+    <!-- Hero Section -->
+    <section class="relative bg-gradient-to-br from-gray-900 via-green-900 to-emerald-900 py-32 px-4 sm:px-6 lg:px-8 overflow-hidden">
+        <div class="absolute inset-0 bg-black/20"></div>
+        <div class="relative max-w-7xl mx-auto grid grid-cols-1 lg:grid-cols-2 gap-16 items-center">
+            <div>
+                <div class="inline-flex items-center px-4 py-2 rounded-full text-sm font-medium bg-green-500/20 text-green-300 border border-green-400/30 mb-6">
+                    <span class="mr-2">🚀</span>
+                    World Class Web Solutions
+                </div>
+                <h1 class="text-4xl sm:text-5xl lg:text-5xl font-bold text-white mb-6 leading-tight">
+                    Orbas Agency
+                </h1>
+                <p class="text-lg sm:text-xl text-gray-300 mb-10 leading-relaxed">
+                    Our specialists craft high-impact websites, mobile apps and automation tools to accelerate your business growth.
+                </p>
+                <a href="mailto:agency@orbas.io" class="inline-flex items-center justify-center px-8 py-4 bg-white/10 hover:bg-white/20 text-white font-semibold rounded-xl transition-all duration-200 shadow-lg hover:shadow-xl transform hover:-translate-y-1">
+                    Contact Agency
+                    <svg class="ml-2 w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+                    </svg>
+                </a>
+            </div>
+            <div class="relative">
+                <div class="relative overflow-hidden rounded-2xl shadow-2xl">
+                    <img src="attached_assets/Freelancer_1752430264371.jpg" alt="Agency" class="w-full h-[500px] object-cover transform hover:scale-105 transition-transform duration-700">
+                    <div class="absolute inset-0 bg-gradient-to-t from-green-900/50 via-transparent to-transparent"></div>
+                    <div class="absolute bottom-6 left-6 right-6">
+                        <div class="bg-white/10 backdrop-blur-md rounded-xl p-4 border border-white/20 flex items-center">
+                            <img src="attached_assets/Orbas agency_1752430278495.png" alt="Orbas Agency" class="w-12 h-12 mr-4">
+                            <div>
+                                <h3 class="text-white font-semibold text-lg mb-1">Full-Service Development</h3>
+                                <p class="text-gray-200 text-sm">Delivering sites and apps that scale with your business</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Services Section -->
+    <section class="py-20 px-4 sm:px-6 lg:px-8 bg-white">
+        <div class="max-w-5xl mx-auto text-center">
+            <h2 class="text-3xl sm:text-4xl font-bold text-gray-900 mb-6">Our Services</h2>
+            <p class="text-lg text-gray-600 mb-10 leading-relaxed">Orbas Agency delivers end-to-end digital solutions tailored for enterprises and ambitious start-ups.</p>
+            <ul class="grid grid-cols-1 sm:grid-cols-2 gap-6 text-left text-gray-700">
+                <li class="flex"><span class="font-bold text-orbas-green mr-2">1.</span>Whitelabel Turnkey Solutions Web & Mobile</li>
+                <li class="flex"><span class="font-bold text-orbas-green mr-2">2.</span>Mobile Apps</li>
+                <li class="flex"><span class="font-bold text-orbas-green mr-2">3.</span>Web Applications and Websites</li>
+                <li class="flex"><span class="font-bold text-orbas-green mr-2">4.</span>Web Design</li>
+                <li class="flex"><span class="font-bold text-orbas-green mr-2">5.</span>Blockchain Development</li>
+                <li class="flex"><span class="font-bold text-orbas-green mr-2">6.</span>A.I. Automations</li>
+                <li class="flex"><span class="font-bold text-orbas-green mr-2">7.</span>Marketing Solutions</li>
+            </ul>
+        </div>
+    </section>
+
+    <!-- Packages Section -->
+    <section class="py-20 px-4 sm:px-6 lg:px-8 bg-gray-50">
+        <div class="max-w-5xl mx-auto text-center">
+            <h2 class="text-3xl sm:text-4xl font-bold text-gray-900 mb-12">Packages</h2>
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+                <div class="p-6 bg-white rounded-xl shadow-lg border border-gray-100">
+                    <h3 class="text-xl font-semibold mb-3">Intro Package</h3>
+                    <p class="text-gray-600 mb-4">Perfect for start-ups launching their first product.</p>
+                    <p class="text-2xl font-bold text-orbas-green">£999.99</p>
+                </div>
+                <div class="p-6 bg-white rounded-xl shadow-lg border border-gray-100">
+                    <h3 class="text-xl font-semibold mb-3">Pro-Enterprise Package</h3>
+                    <p class="text-gray-600 mb-4">Advanced functionality and integrations.</p>
+                    <p class="text-2xl font-bold text-orbas-green">£2500+</p>
+                </div>
+                <div class="p-6 bg-white rounded-xl shadow-lg border border-gray-100">
+                    <h3 class="text-xl font-semibold mb-3">Corporate Package</h3>
+                    <p class="text-gray-600 mb-4">Comprehensive custom solution for large organisations.</p>
+                    <p class="text-2xl font-bold text-orbas-green">£10,000+</p>
+                </div>
+            </div>
+            <p class="mt-8 text-gray-600">Please contact <a href="mailto:agency@orbas.io" class="text-orbas-blue underline">agency@orbas.io</a> for enquiries or open the chat bubble to ask us about our agency service.</p>
+            <p class="mt-4 text-gray-600">We also have work available for freelancers. Email <a href="mailto:support@orbas.io" class="text-orbas-blue underline">support@orbas.io</a> with the subject <strong>Agency Work</strong>, and include your CV, cover letter and hourly fees.</p>
+        </div>
+    </section>
+
+    <!-- Footer -->
+    <footer class="py-16 px-4 sm:px-6 lg:px-8 bg-gray-900 text-white">
+        <div class="max-w-7xl mx-auto">
+            <div class="grid grid-cols-1 lg:grid-cols-4 gap-12 mb-12">
+                <div class="lg:col-span-2">
+                    <div class="rounded-lg p-3 inline-block mb-6">
+                       <img src="https://i.ibb.co/fdy2kZSQ/32eaec67-13fe-45fd-8fc5-b4330a5cc9b3.png" alt="Orbas Logo" class="h-12 w-auto">
+                    </div>
+                    <p class="text-gray-300 leading-relaxed text-lg mb-6">
+                        The complete ecosystem for digital innovation, connecting enterprises with AI-powered solutions,
+                        top talent, learning resources, and automated services that drive business transformation.
+                    </p>
+                    <div class="flex space-x-6">
+                        <a href="mailto:support@orbas.io" class="text-gray-400 hover:text-white transition-colors">
+                            <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
+                                <path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/>
+                            </svg>
+                        </a>
+                        <a href="https://orbas.io" class="text-gray-400 hover:text-white transition-colors">
+                            <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
+                                <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
+                            </svg>
+                        </a>
+                    </div>
+                </div>
+
+                <div>
+                    <h4 class="text-lg font-bold mb-6 text-white">Platforms</h4>
+                    <ul class="space-y-4 text-gray-300">
+                        <li>
+                            <a href="https://ai.orbas.io" class="hover:text-white transition-colors flex items-center">
+                                <span class="w-2 h-2 bg-purple-500 rounded-full mr-3"></span>
+                                Orbas AI
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://freelance.orbas.io" class="hover:text-white transition-colors flex items-center">
+                                <span class="w-2 h-2 bg-orange-500 rounded-full mr-3"></span>
+                                Orbas Freelance
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://jobs.orbas.io" class="hover:text-white transition-colors flex items-center">
+                                <span class="w-2 h-2 bg-green-500 rounded-full mr-3"></span>
+                                Orbas Jobs
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://learn.orbas.io" class="hover:text-white transition-colors flex items-center">
+                                <span class="w-2 h-2 bg-blue-500 rounded-full mr-3"></span>
+                                Orbas Learn
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://services.orbas.io" class="hover:text-white transition-colors flex items-center">
+                                <span class="w-2 h-2 bg-indigo-500 rounded-full mr-3"></span>
+                                Orbas Services
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+
+                <div>
+                    <h4 class="text-lg font-bold mb-6 text-white">Company</h4>
+                    <ul class="space-y-4 text-gray-300">
+                        <li>
+                            <a href="index.html#about" class="hover:text-white transition-colors">About Orbas</a>
+                        </li>
+                        <li>
+                            <a href="agency.html" class="hover:text-white transition-colors">Orbas Agency</a>
+                        </li>
+                        <li>
+                            <a href="privacy.html" class="hover:text-white transition-colors">Privacy Policy</a>
+                        </li>
+                        <li>
+                            <a href="mailto:privacy@orbas.io" class="hover:text-white transition-colors">Privacy Contact</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+
+            <div class="border-t border-gray-700 pt-8">
+                <div class="flex flex-col lg:flex-row justify-between items-center">
+                    <p class="text-gray-300 text-lg mb-4 lg:mb-0">
+                        © 2025 Orbas. All rights reserved.
+                    </p>
+                    <div class="flex items-center space-x-8 text-gray-400">
+                        <a href="mailto:support@orbas.io" class="hover:text-white transition-colors">support@orbas.io</a>
+                        <a href="mailto:legal@orbas.io" class="hover:text-white transition-colors">legal@orbas.io</a>
+                        <a href="mailto:privacy@orbas.io" class="hover:text-white transition-colors">privacy@orbas.io</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <!-- Chatwoot -->
+    <script>
+      (function(d,t) {
+        var BASE_URL="https://support.orbas.io";
+        var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
+        g.src=BASE_URL+"/packs/js/sdk.js";
+        g.defer = true;
+        g.async = true;
+        s.parentNode.insertBefore(g,s);
+        g.onload=function(){
+          window.chatwootSDK.run({
+            websiteToken: 'BqxZWWuiqYY56MzSsbLMTRqn',
+            baseUrl: BASE_URL
+          })
+        }
+      })(document,"script");
+    </script>
+</body>
+</html>

--- a/OrbusLanding/index.html
+++ b/OrbusLanding/index.html
@@ -74,7 +74,7 @@
                     <!-- Tagline -->
                     <div class="inline-flex items-center px-4 py-2 rounded-full text-sm font-medium bg-blue-500/20 text-blue-300 border border-blue-400/30 mb-6">
                         <span class="mr-2">⚡</span>
-                        Transforming Enterprises Through Intelligent Automation
+                        Unleash Innovation with Intelligent Automation
                     </div>
                     
                     <h1 class="text-4xl sm:text-5xl lg:text-5xl font-bold text-white mb-6 leading-tight">
@@ -86,7 +86,7 @@
                     </h1>
                     
                     <p class="text-lg sm:text-xl text-gray-300 mb-10 leading-relaxed">
-                        Five unified platforms provide AI-driven automation, expert talent, advanced learning and streamlined services—all designed to accelerate business growth at industry-leading value.
+                        Five unified platforms provide AI-driven automation, expert talent, advanced learning and streamlined services—plus a world-class agency ready to build your next project. Everything operates 24/7 so your business never slows down.
                     </p>
                     
                     <div class="flex flex-col sm:flex-row gap-6">
@@ -98,6 +98,12 @@
                         </a>
                         <a href="#contact" class="inline-flex items-center justify-center px-8 py-4 bg-white/10 hover:bg-white/20 text-white font-semibold rounded-xl transition-all duration-200 shadow-lg hover:shadow-xl transform hover:-translate-y-1">
                             Contact Sales
+                            <svg class="ml-2 w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+                            </svg>
+                        </a>
+                        <a href="agency.html" class="inline-flex items-center justify-center px-8 py-4 bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white font-semibold rounded-xl transition-all duration-200 shadow-lg hover:shadow-xl transform hover:-translate-y-1">
+                            Work with Our Agency
                             <svg class="ml-2 w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
                             </svg>
@@ -125,6 +131,7 @@
             </div>
         </div>
     </section>
+
 
     <!-- About Section -->
     <section id="about" class="py-24 px-4 sm:px-6 lg:px-8 bg-white">
@@ -385,8 +392,7 @@
                     <div class="lg:w-2/3 p-8">
                         <h3 class="text-2xl font-bold text-gray-900 mb-4">Orbas Services</h3>
                         <p class="text-gray-600 mb-6 leading-relaxed">
-                            On-demand service platform for providers, service providers, and customers. Easy booking of services from accountants and HVAC 
-                            to construction services and more. Everything you need is available with competitive pricing.
+                            24/7 on-demand services connecting providers and clients. Book anything from accountants and HVAC to construction with ease—all at competitive prices whenever you need them.
                         </p>
                         
                         <!-- Features Grid -->
@@ -429,13 +435,27 @@
         </div>
     </section>
 
+    <!-- Agency CTA Section -->
+    <section class="py-20 bg-gradient-to-r from-green-500 via-emerald-500 to-teal-500 text-white text-center">
+        <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
+            <h2 class="text-3xl sm:text-4xl font-bold mb-6">Need a Bespoke Solution?</h2>
+            <p class="text-lg mb-8">Our in-house agency builds stunning websites, mobile apps and automations tailored to your goals. Tell us your budget—we’ll craft a package that works for you.</p>
+            <a href="agency.html" class="inline-flex items-center justify-center px-10 py-4 bg-white text-green-700 font-semibold rounded-xl shadow-lg hover:bg-gray-100 transition-all duration-200">
+                Learn About Orbas Agency
+                <svg class="ml-3 w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+                </svg>
+            </a>
+        </div>
+    </section>
+
     <!-- Contact & Support Section -->
     <section id="contact" class="py-16 px-4 sm:px-6 lg:px-8 bg-gray-50">
         <div class="max-w-4xl mx-auto">
             <div class="text-center mb-12">
                 <h2 class="text-3xl font-bold text-gray-900 mb-4">Contact & Support</h2>
                 <p class="text-lg text-gray-600">
-                    For enquiries or bespoke solutions, reach out to our dedicated experts.
+                    Our experts are available 24/7 for bespoke solutions and rapid support.
                 </p>
             </div>
 

--- a/OrbusLanding/index.html
+++ b/OrbusLanding/index.html
@@ -3,8 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Orbas Main Site - Complete Ecosystem for Digital Innovation</title>
-    <meta name="description" content="Explore the complete Orbas ecosystem - AI platforms, freelance services, job marketplace, learning resources, and automated agency solutions for enterprise success.">
+    <title>Orbas Ecosystem - Digital Transformation Partner</title>
+    <meta name="description" content="Enterprise-ready ecosystem delivering AI solutions, professional talent, learning management and on-demand services for scalable digital transformation.">
     
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
@@ -53,7 +53,9 @@
                 
                 <!-- Navigation -->
                 <nav class="hidden md:flex space-x-8">
+                    <a href="#about" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">About</a>
                     <a href="#platforms" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Platforms</a>
+                    <a href="agency.html" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Agency</a>
                     <a href="#contact" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Contact</a>
                     <a href="privacy.html" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Privacy</a>
                 </nav>
@@ -72,7 +74,7 @@
                     <!-- Tagline -->
                     <div class="inline-flex items-center px-4 py-2 rounded-full text-sm font-medium bg-blue-500/20 text-blue-300 border border-blue-400/30 mb-6">
                         <span class="mr-2">⚡</span>
-                        Powering Enterprise Digital Innovation
+                        Transforming Enterprises Through Intelligent Automation
                     </div>
                     
                     <h1 class="text-4xl sm:text-5xl lg:text-5xl font-bold text-white mb-6 leading-tight">
@@ -80,15 +82,22 @@
                         <span class="bg-gradient-to-r from-blue-400 via-purple-400 to-pink-400 bg-clip-text text-transparent">
                             Orbas Ecosystem
                         </span>
+                        for Digital Transformation
                     </h1>
                     
                     <p class="text-lg sm:text-xl text-gray-300 mb-10 leading-relaxed">
-                        Five integrated platforms delivering AI automation, premium talent, enterprise learning, on-demand services, and intelligent recruitment - all with industry-leading low fees.
+                        Five unified platforms provide AI-driven automation, expert talent, advanced learning and streamlined services—all designed to accelerate business growth at industry-leading value.
                     </p>
                     
                     <div class="flex flex-col sm:flex-row gap-6">
                         <a href="#platforms" class="inline-flex items-center justify-center px-8 py-4 bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white font-semibold rounded-xl transition-all duration-200 shadow-lg hover:shadow-xl transform hover:-translate-y-1">
                             Explore Platforms
+                            <svg class="ml-2 w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+                            </svg>
+                        </a>
+                        <a href="#contact" class="inline-flex items-center justify-center px-8 py-4 bg-white/10 hover:bg-white/20 text-white font-semibold rounded-xl transition-all duration-200 shadow-lg hover:shadow-xl transform hover:-translate-y-1">
+                            Contact Sales
                             <svg class="ml-2 w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
                             </svg>
@@ -112,6 +121,30 @@
                     <!-- Floating elements -->
                     <div class="absolute -top-4 -right-4 w-20 h-20 bg-gradient-to-br from-purple-400 to-pink-500 rounded-full opacity-60 animate-pulse"></div>
                     <div class="absolute -bottom-4 -left-4 w-16 h-16 bg-gradient-to-br from-blue-400 to-cyan-500 rounded-full opacity-40 animate-bounce"></div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- About Section -->
+    <section id="about" class="py-24 px-4 sm:px-6 lg:px-8 bg-white">
+        <div class="max-w-4xl mx-auto text-center">
+            <h2 class="text-3xl sm:text-4xl font-bold text-gray-900 mb-6">About Orbas</h2>
+            <p class="text-lg text-gray-600 mb-8 leading-relaxed">
+                Orbas delivers enterprise-grade solutions across AI, talent, learning and services. Our mission is to simplify digital transformation with secure, scalable and user-friendly platforms.
+            </p>
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+                <div class="p-6 bg-gray-50 rounded-lg">
+                    <h3 class="font-semibold text-gray-900 mb-2">Security First</h3>
+                    <p class="text-gray-600 text-sm leading-relaxed">Robust data protection and compliance practices safeguard your information.</p>
+                </div>
+                <div class="p-6 bg-gray-50 rounded-lg">
+                    <h3 class="font-semibold text-gray-900 mb-2">Scalable Infrastructure</h3>
+                    <p class="text-gray-600 text-sm leading-relaxed">Enterprise-ready architecture grows alongside your organisation.</p>
+                </div>
+                <div class="p-6 bg-gray-50 rounded-lg">
+                    <h3 class="font-semibold text-gray-900 mb-2">Dedicated Expertise</h3>
+                    <p class="text-gray-600 text-sm leading-relaxed">Our team provides continuous innovation and reliable support.</p>
                 </div>
             </div>
         </div>
@@ -397,12 +430,12 @@
     </section>
 
     <!-- Contact & Support Section -->
-    <section class="py-16 px-4 sm:px-6 lg:px-8 bg-gray-50">
+    <section id="contact" class="py-16 px-4 sm:px-6 lg:px-8 bg-gray-50">
         <div class="max-w-4xl mx-auto">
             <div class="text-center mb-12">
                 <h2 class="text-3xl font-bold text-gray-900 mb-4">Contact & Support</h2>
                 <p class="text-lg text-gray-600">
-                    Need assistance or have questions? Our dedicated support team is here to help.
+                    For enquiries or bespoke solutions, reach out to our dedicated experts.
                 </p>
             </div>
 
@@ -512,6 +545,16 @@
                     <h4 class="text-lg font-bold mb-6 text-white">Company</h4>
                     <ul class="space-y-4 text-gray-300">
                         <li>
+                            <a href="#about" class="hover:text-white transition-colors">
+                                About Orbas
+                            </a>
+                        </li>
+                        <li>
+                            <a href="agency.html" class="hover:text-white transition-colors">
+                                Orbas Agency
+                            </a>
+                        </li>
+                        <li>
                             <a href="mailto:legal@orbas.io" class="hover:text-white transition-colors">
                                 Legal Team
                             </a>
@@ -544,5 +587,22 @@
             </div>
         </div>
     </footer>
+    <!-- Chatwoot -->
+    <script>
+      (function(d,t) {
+        var BASE_URL="https://support.orbas.io";
+        var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
+        g.src=BASE_URL+"/packs/js/sdk.js";
+        g.defer = true;
+        g.async = true;
+        s.parentNode.insertBefore(g,s);
+        g.onload=function(){
+          window.chatwootSDK.run({
+            websiteToken: 'BqxZWWuiqYY56MzSsbLMTRqn',
+            baseUrl: BASE_URL
+          })
+        }
+      })(document,"script");
+    </script>
 </body>
 </html>

--- a/OrbusLanding/privacy.html
+++ b/OrbusLanding/privacy.html
@@ -4,19 +4,19 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Privacy Policy - Orbas Ecosystem | Blackridge Group Ltd</title>
-    
+
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <link rel="alternate icon" href="favicon.svg">
-    
+
     <!-- Google Fonts - Poppins -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
-    
+
     <!-- Tailwind CSS -->
     <script src="https://cdn.tailwindcss.com"></script>
-    
+
     <!-- Custom Tailwind Config -->
     <script>
         tailwind.config = {
@@ -40,22 +40,33 @@
         }
     </script>
 </head>
-<body class="bg-gray-50 text-gray-900 font-poppins antialiased min-h-screen">
-    <!-- Header -->
-    <header class="bg-white border-b border-gray-200">
-        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-            <div class="flex items-center justify-between">
-                <div>
-                    <img src="attached_assets/orbas logo_1752425860914.png" alt="Orbas Logo" class="h-12 w-auto mb-2">
-                    <h1 class="text-3xl font-bold text-gray-900">Privacy Policy</h1>
-                    <p class="text-gray-600 mt-2">Blackridge Group Ltd trading as Orbas</p>
+<body class="bg-white text-gray-900 font-poppins antialiased">
+    <!-- Header Navigation -->
+    <header class="bg-white border-b border-gray-200 sticky top-0 z-50">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex justify-between items-center h-16">
+                <!-- Logo -->
+                <div class="flex items-center">
+                    <img src="attached_assets/orbas logo_1752425860914.png" alt="Orbas Logo" class="h-12 w-auto">
                 </div>
-                <a href="index.html" class="inline-flex items-center text-orbas-blue hover:text-orbas-dark-blue font-medium transition-colors">
-                    ← Back to Home
-                </a>
+
+                <!-- Navigation -->
+                <nav class="hidden md:flex space-x-8">
+                    <a href="index.html#about" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">About</a>
+                    <a href="index.html#platforms" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Platforms</a>
+                    <a href="agency.html" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Agency</a>
+                    <a href="index.html#contact" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Contact</a>
+                    <a href="privacy.html" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Privacy</a>
+                </nav>
             </div>
         </div>
     </header>
+
+    <!-- Page Title -->
+    <section class="bg-gradient-to-br from-gray-900 via-blue-900 to-purple-900 py-20 text-center text-white">
+        <h1 class="text-4xl sm:text-5xl font-bold">Privacy Policy</h1>
+        <p class="mt-2 text-lg">Blackridge Group Ltd trading as Orbas</p>
+    </section>
 
     <!-- Main Content -->
     <main class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
@@ -65,7 +76,7 @@
                     <h2 class="text-4xl font-bold text-gray-900 mb-4">Privacy Policy for Orbas Ecosystem</h2>
                     <div class="bg-blue-50 border-l-4 border-blue-400 p-4 mb-6">
                         <p class="text-blue-800 font-medium">Last updated: July 13, 2025</p>
-                        <p class="text-blue-700 text-sm mt-1">This policy is compliant with UK GDPR and Data Protection Act 2018</p>
+                        <p class="text-blue-700 text-sm mt-1">This policy is compliant with UK GDPR and the Data Protection Act 2018</p>
                     </div>
                 </div>
 
@@ -73,17 +84,73 @@
                 <div class="bg-gray-50 p-6 rounded-lg mb-6">
                     <p class="text-gray-700 mb-2"><strong>Company:</strong> Blackridge Group Ltd (trading as Orbas)</p>
                     <p class="text-gray-700 mb-2"><strong>Registration:</strong> UK Company Registration Number 16482166</p>
-                    <p class="text-gray-700 mb-2"><strong>Data Protection Officer:</strong> privacy@orbas.io</p>
-                    <p class="text-gray-700 mb-2"><strong>Legal Contact:</strong> legal@orbas.io</p>
-                    <p class="text-gray-700"><strong>Support Contact:</strong> support@orbas.io</p>
+                    <p class="text-gray-700 mb-2"><strong>Data Protection Officer:</strong> <a href="mailto:privacy@orbas.io">privacy@orbas.io</a></p>
+                    <p class="text-gray-700 mb-2"><strong>Legal Contact:</strong> <a href="mailto:legal@orbas.io">legal@orbas.io</a></p>
+                    <p class="text-gray-700"><strong>Support Contact:</strong> <a href="mailto:support@orbas.io">support@orbas.io</a></p>
                 </div>
 
                 <h3 class="text-2xl font-semibold text-gray-900 mb-4">2. Introduction and Legal Basis</h3>
                 <p class="text-gray-700 mb-6">
-                    This Privacy Policy describes how Blackridge Group Ltd, trading as Orbas ("we," "our," or "us"), collects, uses, and protects your personal information under the UK General Data Protection Regulation (UK GDPR) and the Data Protection Act 2018. This policy applies to our comprehensive ecosystem of platforms, including Orbas AI, Orbas Freelance, Orbas Jobs, Orbas Learn, Orbas Services, and Orbas Agency.
+                    This Privacy Policy explains how we collect, use and protect your personal information when you interact with any part of the Orbas ecosystem. We process personal data in accordance with the UK General Data Protection Regulation (UK GDPR) and the Data Protection Act 2018. Our legal bases for processing include consent, contract performance, compliance with legal obligations and our legitimate business interests.
+                </p>
+                <p class="text-gray-700 mb-6">Our services are not directed to children under 13, and we do not knowingly collect their personal information. If you become aware of a child providing us data, please contact us to request deletion.</p>
+                <h3 class="text-2xl font-semibold text-gray-900 mb-4">3. How We Collect Personal Data</h3>
+                <ul class="list-disc pl-6 text-gray-700 mb-6">
+                    <li>Directly from you when you provide information through our platforms or contact us.</li>
+                    <li>Automatically through cookies and similar technologies as you browse our sites.</li>
+                    <li>From trusted partners that help us operate and promote our services.</li>
+                </ul>
+
+                <h3 class="text-2xl font-semibold text-gray-900 mb-4">4. Personal Data We Collect</h3>
+                <ul class="list-disc pl-6 text-gray-700 mb-6">
+                    <li>Contact details such as name, email address and phone number when you communicate with us.</li>
+                    <li>Account information for our platforms including usernames, preferences and billing details.</li>
+                    <li>Usage data like IP addresses, browser type and pages visited collected through cookies and analytics tools.</li>
+                    <li>Any other information you choose to provide when using our services.</li>
+                </ul>
+
+                <h3 class="text-2xl font-semibold text-gray-900 mb-4">5. How We Use Personal Data</h3>
+                <ul class="list-disc pl-6 text-gray-700 mb-6">
+                    <li>To operate, maintain and improve our platforms and services.</li>
+                    <li>To communicate with you, respond to enquiries and provide customer support.</li>
+                    <li>To process transactions and deliver products or services you request.</li>
+                    <li>To send marketing communications where you have provided consent.</li>
+                    <li>To comply with legal obligations and enforce our terms.</li>
+                </ul>
+
+                <h3 class="text-2xl font-semibold text-gray-900 mb-4">6. Cookies and Tracking Technologies</h3>
+                <p class="text-gray-700 mb-6">We use cookies to operate our websites, remember preferences and analyse traffic. You can manage or disable cookies in your browser settings.</p>
+                <ul class="list-disc pl-6 text-gray-700 mb-6">
+                    <li><strong>Essential cookies</strong> for site functionality and security.</li>
+                    <li><strong>Functional cookies</strong> to remember your preferences.</li>
+                    <li><strong>Analytics cookies</strong> to understand site usage.</li>
+                    <li><strong>Marketing cookies</strong> used with consent for advertising.</li>
+                </ul>
+
+                <h3 class="text-2xl font-semibold text-gray-900 mb-4">7. Data Sharing and Third Parties</h3>
+                <p class="text-gray-700 mb-6">
+                    We may share your information with trusted service providers who perform services on our behalf, such as hosting, analytics and marketing. These providers are bound by data processing agreements and may only use your data in accordance with our instructions. We will never sell your personal data.
                 </p>
 
-                <h3 class="text-2xl font-semibold text-gray-900 mb-4">3. Your Rights Under UK GDPR</h3>
+                <p class="text-gray-700 mb-6">We may provide links to third-party websites for your convenience. Those sites operate independently from us, and we encourage you to review their privacy notices.</p>
+                <h3 class="text-2xl font-semibold text-gray-900 mb-4">8. International Data Transfers</h3>
+                <p class="text-gray-700 mb-6">
+                    Where personal data is transferred outside the UK, we ensure appropriate safeguards are in place, including adequacy regulations or Standard Contractual Clauses.
+                </p>
+
+                <h3 class="text-2xl font-semibold text-gray-900 mb-4">9. Data Security Measures</h3>
+                <p class="text-gray-700 mb-6">
+                    We implement technical and organisational measures to protect your data, including encryption, access controls and regular security reviews.
+                </p>
+
+                <h3 class="text-2xl font-semibold text-gray-900 mb-4">10. Data Retention</h3>
+                <p class="text-gray-700 mb-6">
+                    We retain personal data only for as long as necessary to fulfil the purposes described in this policy, comply with legal obligations and resolve disputes.
+                </p>
+                <h3 class="text-2xl font-semibold text-gray-900 mb-4">11. Automated Decision-Making and Profiling</h3>
+                <p class="text-gray-700 mb-6">We do not use your personal data for automated decision-making that produces legal effects. If this changes, we will inform you and explain your rights.</p>
+
+                <h3 class="text-2xl font-semibold text-gray-900 mb-4">12. Your Rights Under UK GDPR</h3>
                 <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
                     <div class="space-y-4">
                         <div class="border border-blue-200 rounded-lg p-4">
@@ -115,15 +182,15 @@
                     </div>
                 </div>
 
-                <h3 class="text-2xl font-semibold text-gray-900 mb-4">4. Contact Information and Complaints</h3>
+                <h3 class="text-2xl font-semibold text-gray-900 mb-4">13. Contact Information and Complaints</h3>
                 <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
                     <div class="bg-gray-50 p-6 rounded-lg">
                         <h4 class="font-medium text-gray-900 mb-4">Data Protection Contacts</h4>
                         <div class="space-y-2 text-sm text-gray-700">
-                            <p><strong>Data Protection Officer:</strong> privacy@orbas.io</p>
-                            <p><strong>Data Subject Requests:</strong> privacy@orbas.io</p>
-                            <p><strong>General Support:</strong> support@orbas.io</p>
-                            <p><strong>Legal Team:</strong> legal@orbas.io</p>
+                            <p><strong>Data Protection Officer:</strong> <a href="mailto:privacy@orbas.io">privacy@orbas.io</a></p>
+                            <p><strong>Data Subject Requests:</strong> <a href="mailto:privacy@orbas.io">privacy@orbas.io</a></p>
+                            <p><strong>General Support:</strong> <a href="mailto:support@orbas.io">support@orbas.io</a></p>
+                            <p><strong>Legal Team:</strong> <a href="mailto:legal@orbas.io">legal@orbas.io</a></p>
                         </div>
                     </div>
                     <div class="bg-gray-50 p-6 rounded-lg">
@@ -138,6 +205,9 @@
                         </p>
                     </div>
                 </div>
+
+                <h3 class="text-2xl font-semibold text-gray-900 mb-4">14. Changes to This Policy</h3>
+                <p class="text-gray-700 mb-6">We may update this policy from time to time. Any changes will be posted on this page and, where appropriate, notified to you by email.</p>
 
                 <div class="bg-gray-100 p-6 rounded-lg">
                     <h4 class="font-medium text-gray-900 mb-2">Document Information</h4>
@@ -154,20 +224,124 @@
     </main>
 
     <!-- Footer -->
-    <footer class="bg-gray-900 text-white py-8">
-        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex flex-col lg:flex-row justify-between items-center">
-                <div class="mb-4 lg:mb-0">
-                    <p class="text-gray-300">© 2025 Blackridge Group Ltd trading as Orbas. All rights reserved.</p>
-                    <p class="text-gray-400 text-sm mt-1">UK Company Registration: 16482166</p>
+    <footer class="py-16 px-4 sm:px-6 lg:px-8 bg-gray-900 text-white">
+        <div class="max-w-7xl mx-auto">
+            <div class="grid grid-cols-1 lg:grid-cols-4 gap-12 mb-12">
+                <div class="lg:col-span-2">
+                    <div class="rounded-lg p-3 inline-block mb-6">
+                       <img src="https://i.ibb.co/fdy2kZSQ/32eaec67-13fe-45fd-8fc5-b4330a5cc9b3.png" alt="Orbas Logo" class="h-12 w-auto">
+                    </div>
+                    <p class="text-gray-300 leading-relaxed text-lg mb-6">
+                        The complete ecosystem for digital innovation, connecting enterprises with AI-powered solutions,
+                        top talent, learning resources, and automated services that drive business transformation.
+                    </p>
+                    <div class="flex space-x-6">
+                        <a href="mailto:support@orbas.io" class="text-gray-400 hover:text-white transition-colors">
+                            <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
+                                <path d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z"/>
+                            </svg>
+                        </a>
+                        <a href="https://orbas.io" class="text-gray-400 hover:text-white transition-colors">
+                            <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
+                                <path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
+                            </svg>
+                        </a>
+                    </div>
                 </div>
-                <div class="flex space-x-6">
-                    <a href="mailto:privacy@orbas.io" class="text-gray-400 hover:text-white transition-colors">privacy@orbas.io</a>
-                    <a href="mailto:legal@orbas.io" class="text-gray-400 hover:text-white transition-colors">legal@orbas.io</a>
-                    <a href="mailto:support@orbas.io" class="text-gray-400 hover:text-white transition-colors">support@orbas.io</a>
+
+                <div>
+                    <h4 class="text-lg font-bold mb-6 text-white">Platforms</h4>
+                    <ul class="space-y-4 text-gray-300">
+                        <li>
+                            <a href="https://ai.orbas.io" class="hover:text-white transition-colors flex items-center">
+                                <span class="w-2 h-2 bg-purple-500 rounded-full mr-3"></span>
+                                Orbas AI
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://freelance.orbas.io" class="hover:text-white transition-colors flex items-center">
+                                <span class="w-2 h-2 bg-orange-500 rounded-full mr-3"></span>
+                                Orbas Freelance
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://jobs.orbas.io" class="hover:text-white transition-colors flex items-center">
+                                <span class="w-2 h-2 bg-green-500 rounded-full mr-3"></span>
+                                Orbas Jobs
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://learn.orbas.io" class="hover:text-white transition-colors flex items-center">
+                                <span class="w-2 h-2 bg-blue-500 rounded-full mr-3"></span>
+                                Orbas Learn
+                            </a>
+                        </li>
+                        <li>
+                            <a href="https://services.orbas.io" class="hover:text-white transition-colors flex items-center">
+                                <span class="w-2 h-2 bg-indigo-500 rounded-full mr-3"></span>
+                                Orbas Services
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+
+                <div>
+                    <h4 class="text-lg font-bold mb-6 text-white">Company</h4>
+                    <ul class="space-y-4 text-gray-300">
+                        <li>
+                            <a href="mailto:legal@orbas.io" class="hover:text-white transition-colors">
+                                Legal Team
+                            </a>
+                        </li>
+                        <li>
+                            <a href="agency.html" class="hover:text-white transition-colors">
+                                Orbas Agency
+                            </a>
+                        </li>
+                        <li>
+                            <a href="privacy.html" class="hover:text-white transition-colors">
+                                Privacy Policy
+                            </a>
+                        </li>
+                        <li>
+                            <a href="mailto:privacy@orbas.io" class="hover:text-white transition-colors">
+                                Privacy Contact
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+
+            <div class="border-t border-gray-700 pt-8">
+                <div class="flex flex-col lg:flex-row justify-between items-center">
+                    <p class="text-gray-300 text-lg mb-4 lg:mb-0">
+                        © 2025 Orbas. All rights reserved.
+                    </p>
+                    <div class="flex items-center space-x-8 text-gray-400">
+                        <a href="mailto:support@orbas.io" class="hover:text-white transition-colors">support@orbas.io</a>
+                        <a href="mailto:legal@orbas.io" class="hover:text-white transition-colors">legal@orbas.io</a>
+                        <a href="mailto:privacy@orbas.io" class="hover:text-white transition-colors">privacy@orbas.io</a>
+                    </div>
                 </div>
             </div>
         </div>
     </footer>
+    <!-- Chatwoot -->
+    <script>
+      (function(d,t) {
+        var BASE_URL="https://support.orbas.io";
+        var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
+        g.src=BASE_URL+"/packs/js/sdk.js";
+        g.defer = true;
+        g.async = true;
+        s.parentNode.insertBefore(g,s);
+        g.onload=function(){
+          window.chatwootSDK.run({
+            websiteToken: 'BqxZWWuiqYY56MzSsbLMTRqn',
+            baseUrl: BASE_URL
+          })
+        }
+      })(document,"script");
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Chatwoot support widget on all pages
- fix Contact Sales anchor and add Agency links in navigation
- create new `agency.html` detailing Orbas Agency services and packages

## Testing
- `grep -R "privacy.html" -n | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68897cb2ef4c832084c25ea1dcbae794