### PR TITLE
Highlight blockchain as future innovation on homepage

### DIFF
--- a/OrbusLanding/index.html
+++ b/OrbusLanding/index.html
@@ -161,7 +161,7 @@
             <p class="text-lg text-gray-600 mb-8 leading-relaxed">
                 Orbas delivers enterprise-grade solutions across AI, talent, learning and services. Our mission is to simplify digital transformation with secure, scalable and user-friendly platforms.
             </p>
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
                 <div class="p-6 bg-gray-50 rounded-lg">
                     <h3 class="font-semibold text-gray-900 mb-2">Security First</h3>
                     <p class="text-gray-600 text-sm leading-relaxed">Robust data protection and compliance practices safeguard your information.</p>
@@ -173,6 +173,10 @@
                 <div class="p-6 bg-gray-50 rounded-lg">
                     <h3 class="font-semibold text-gray-900 mb-2">Dedicated Expertise</h3>
                     <p class="text-gray-600 text-sm leading-relaxed">Our team provides continuous innovation and reliable support.</p>
+                </div>
+                <div class="p-6 bg-gray-50 rounded-lg">
+                    <h3 class="font-semibold text-gray-900 mb-2">Future Innovation</h3>
+                    <p class="text-gray-600 text-sm leading-relaxed">Blockchain integration is part of our roadmap to power trusted global transactions.</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- add "Future Innovation" card to About section explaining blockchain roadmap
- expand layout to four responsive columns

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68995b3758c083209e3088cbb4344837