### PR TITLE
Add Blackridge Group footer link

### DIFF
--- a/OrbusLanding/agency.html
+++ b/OrbusLanding/agency.html
@@ -323,6 +323,7 @@
                         <a href="mailto:support@orbas.io" class="hover:text-black transition-colors">support@orbas.io</a>
                         <a href="mailto:legal@orbas.io" class="hover:text-black transition-colors">legal@orbas.io</a>
                         <a href="mailto:privacy@orbas.io" class="hover:text-black transition-colors">privacy@orbas.io</a>
+                        <a href="https://blackridgegroup.online" class="hover:text-black transition-colors">Blackridge Group</a>
                     </div>
                 </div>
             </div>

--- a/OrbusLanding/index.html
+++ b/OrbusLanding/index.html
@@ -651,6 +651,7 @@
                         <a href="mailto:support@orbas.io" class="hover:text-black transition-colors">support@orbas.io</a>
                         <a href="mailto:legal@orbas.io" class="hover:text-black transition-colors">legal@orbas.io</a>
                         <a href="mailto:privacy@orbas.io" class="hover:text-black transition-colors">privacy@orbas.io</a>
+                        <a href="https://blackridgegroup.online" class="hover:text-black transition-colors">Blackridge Group</a>
                     </div>
                 </div>
             </div>

--- a/OrbusLanding/investors.html
+++ b/OrbusLanding/investors.html
@@ -196,6 +196,7 @@
                         <a href="mailto:support@orbas.io" class="hover:text-black transition-colors">support@orbas.io</a>
                         <a href="mailto:legal@orbas.io" class="hover:text-black transition-colors">legal@orbas.io</a>
                         <a href="mailto:privacy@orbas.io" class="hover:text-black transition-colors">privacy@orbas.io</a>
+                        <a href="https://blackridgegroup.online" class="hover:text-black transition-colors">Blackridge Group</a>
                     </div>
                 </div>
             </div>

--- a/OrbusLanding/privacy.html
+++ b/OrbusLanding/privacy.html
@@ -357,6 +357,7 @@
                         <a href="mailto:support@orbas.io" class="hover:text-black transition-colors">support@orbas.io</a>
                         <a href="mailto:legal@orbas.io" class="hover:text-black transition-colors">legal@orbas.io</a>
                         <a href="mailto:privacy@orbas.io" class="hover:text-black transition-colors">privacy@orbas.io</a>
+                        <a href="https://blackridgegroup.online" class="hover:text-black transition-colors">Blackridge Group</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- add Blackridge Group link in site footer across all pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68995b9cb4148320b1444f3f72374c63