### PR TITLE
Use transparent Orbas logo across site

### DIFF
--- a/OrbusLanding/agency.html
+++ b/OrbusLanding/agency.html
@@ -72,7 +72,7 @@
           <div class="flex items-center">
             <a href="index.html">
               <img
-                src="attached_assets/orbas-logo.png"
+                src="https://i.ibb.co/gLcRkc8k/IMG-2726-removebg-preview.png"
                 alt="Orbas Logo"
                 class="h-12 w-auto"
               />
@@ -226,7 +226,7 @@
                 class="bg-white/10 backdrop-blur-md rounded-xl p-4 border border-white/20 flex items-center"
               >
                 <img
-                  src="attached_assets/orbas-logo.png"
+                  src="https://i.ibb.co/gLcRkc8k/IMG-2726-removebg-preview.png"
                   alt="Orbas Logo"
                   class="w-12 h-12 mr-4"
                 />
@@ -509,7 +509,7 @@
           <div class="lg:col-span-2">
             <div class="rounded-lg p-3 inline-block mb-6">
               <img
-                src="attached_assets/orbas-logo.png"
+                src="https://i.ibb.co/gLcRkc8k/IMG-2726-removebg-preview.png"
                 alt="Orbas Logo"
                 class="h-12 w-auto"
               />

--- a/OrbusLanding/index.html
+++ b/OrbusLanding/index.html
@@ -50,7 +50,7 @@
                 <!-- Logo -->
                 <div class="flex items-center">
                     <a href="index.html">
-                        <img src="https://i.ibb.co/7dRPCgrB/IMG-2726.jpg" alt="Orbas Logo" class="h-12 w-auto">
+                        <img src="https://i.ibb.co/gLcRkc8k/IMG-2726-removebg-preview.png" alt="Orbas Logo" class="h-12 w-auto">
                     </a>
                 </div>
                 
@@ -487,7 +487,7 @@
             <div class="grid grid-cols-1 lg:grid-cols-4 gap-12 mb-12">
                 <div class="lg:col-span-2">
                     <div class="rounded-lg p-3 inline-block mb-6">
-                       <img src="https://i.ibb.co/7dRPCgrB/IMG-2726.jpg" alt="Orbas Logo" class="h-12 w-auto">
+                       <img src="https://i.ibb.co/gLcRkc8k/IMG-2726-removebg-preview.png" alt="Orbas Logo" class="h-12 w-auto">
                     </div>
                     <p class="text-gray-700 leading-relaxed text-lg mb-6">
                         The complete ecosystem for digital innovation, connecting enterprises with AI-powered solutions, 

--- a/OrbusLanding/investors.html
+++ b/OrbusLanding/investors.html
@@ -40,7 +40,7 @@
             <div class="flex justify-between items-center h-16">
                 <div class="flex items-center">
                     <a href="index.html">
-                        <img src="https://i.ibb.co/7dRPCgrB/IMG-2726.jpg" alt="Orbas Logo" class="h-12 w-auto">
+                        <img src="https://i.ibb.co/gLcRkc8k/IMG-2726-removebg-preview.png" alt="Orbas Logo" class="h-12 w-auto">
                     </a>
                 </div>
                 <nav class="hidden md:flex space-x-8">
@@ -153,7 +153,7 @@
             <div class="grid grid-cols-1 lg:grid-cols-4 gap-12 mb-12">
                 <div class="lg:col-span-2">
                     <div class="rounded-lg p-3 inline-block mb-6">
-                       <img src="https://i.ibb.co/7dRPCgrB/IMG-2726.jpg" alt="Orbas Logo" class="h-12 w-auto">
+                       <img src="https://i.ibb.co/gLcRkc8k/IMG-2726-removebg-preview.png" alt="Orbas Logo" class="h-12 w-auto">
                     </div>
                     <p class="text-gray-700 leading-relaxed text-lg mb-6">The complete ecosystem for digital innovation, connecting enterprises with AI-powered solutions, top talent, learning resources and automated services that drive business transformation.</p>
                     <div class="flex space-x-6">

--- a/OrbusLanding/privacy.html
+++ b/OrbusLanding/privacy.html
@@ -48,7 +48,7 @@
                 <!-- Logo -->
                 <div class="flex items-center">
                     <a href="index.html">
-                        <img src="https://i.ibb.co/7dRPCgrB/IMG-2726.jpg" alt="Orbas Logo" class="h-12 w-auto">
+                        <img src="https://i.ibb.co/gLcRkc8k/IMG-2726-removebg-preview.png" alt="Orbas Logo" class="h-12 w-auto">
                     </a>
                 </div>
 
@@ -260,7 +260,7 @@
             <div class="grid grid-cols-1 lg:grid-cols-4 gap-12 mb-12">
                 <div class="lg:col-span-2">
                     <div class="rounded-lg p-3 inline-block mb-6">
-                       <img src="https://i.ibb.co/7dRPCgrB/IMG-2726.jpg" alt="Orbas Logo" class="h-12 w-auto">
+                       <img src="https://i.ibb.co/gLcRkc8k/IMG-2726-removebg-preview.png" alt="Orbas Logo" class="h-12 w-auto">
                     </div>
                     <p class="text-gray-700 leading-relaxed text-lg mb-6">
                         The complete ecosystem for digital innovation, connecting enterprises with AI-powered solutions,


### PR DESCRIPTION
## Summary
- Replace header and footer logos on all pages with the provided transparent Orbas logo.
- Update agency page references so every logo points to the same image URL and maintains professional sizing.

## Testing
- `npm test` *(fails: ENOENT could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f99d2cb48320811f33a87087746a