### PR TITLE
Revamp agency CTA and form

### DIFF
--- a/OrbusLanding/agency.html
+++ b/OrbusLanding/agency.html
@@ -222,22 +222,9 @@
               class="absolute inset-0 bg-gradient-to-t from-orbas-dark-blue/50 via-transparent to-transparent"
             ></div>
             <div class="absolute bottom-6 left-6 right-6">
-              <div
-                class="bg-white/10 backdrop-blur-md rounded-xl p-4 border border-white/20 flex items-center"
-              >
-                <img
-                  src="https://i.ibb.co/gLcRkc8k/IMG-2726-removebg-preview.png"
-                  alt="Orbas Logo"
-                  class="w-12 h-12 mr-4"
-                />
-                <div>
-                  <h3 class="text-white font-semibold text-lg mb-1">
-                    Full-Service Development
-                  </h3>
-                  <p class="text-gray-200 text-sm">
-                    Delivering sites and apps that scale with your business
-                  </p>
-                </div>
+              <div class="bg-white/10 backdrop-blur-md rounded-xl p-4 border border-white/20">
+                <h3 class="text-white font-semibold text-lg mb-1">Full-Service Development</h3>
+                <p class="text-gray-200 text-sm">Delivering sites and apps that scale with your business</p>
               </div>
             </div>
           </div>
@@ -513,95 +500,30 @@
         <p class="text-lg text-center mb-12 text-gray-100">
           Share a few details and our team will reach out shortly.
         </p>
-        <form
-          action="https://agency.orbas.io/index.php/collect_leads/save"
-          method="post"
-          class="grid grid-cols-1 md:grid-cols-2 gap-6"
-        >
-          <input
-            type="text"
-            name="company_name"
-            id="company_name"
-            placeholder="Company name"
-            required
-            class="p-4 rounded-lg bg-white text-gray-900 shadow focus:outline-none focus:ring-2 focus:ring-orbas-light-blue"
-          />
-          <input
-            type="text"
-            name="first_name"
-            id="first_name"
-            placeholder="First name"
-            class="p-4 rounded-lg bg-white text-gray-900 shadow focus:outline-none focus:ring-2 focus:ring-orbas-light-blue"
-          />
-          <input
-            type="text"
-            name="last_name"
-            id="last_name"
-            placeholder="Last name"
-            required
-            class="p-4 rounded-lg bg-white text-gray-900 shadow focus:outline-none focus:ring-2 focus:ring-orbas-light-blue"
-          />
-          <input
-            type="email"
-            name="email"
-            id="email"
-            placeholder="Email"
-            autocomplete="off"
-            class="p-4 rounded-lg bg-white text-gray-900 shadow focus:outline-none focus:ring-2 focus:ring-orbas-light-blue md:col-span-2"
-          />
-          <textarea
-            name="address"
-            id="address"
-            placeholder="Address"
-            rows="4"
-            class="p-4 rounded-lg bg-white text-gray-900 shadow focus:outline-none focus:ring-2 focus:ring-orbas-light-blue md:col-span-2"
-          ></textarea>
-          <input
-            type="text"
-            name="city"
-            id="city"
-            placeholder="City"
-            class="p-4 rounded-lg bg-white text-gray-900 shadow focus:outline-none focus:ring-2 focus:ring-orbas-light-blue"
-          />
-          <input
-            type="text"
-            name="state"
-            id="state"
-            placeholder="State"
-            class="p-4 rounded-lg bg-white text-gray-900 shadow focus:outline-none focus:ring-2 focus:ring-orbas-light-blue"
-          />
-          <input
-            type="text"
-            name="zip"
-            id="zip"
-            placeholder="Zip"
-            class="p-4 rounded-lg bg-white text-gray-900 shadow focus:outline-none focus:ring-2 focus:ring-orbas-light-blue"
-          />
-          <input
-            type="text"
-            name="country"
-            id="country"
-            placeholder="Country"
-            class="p-4 rounded-lg bg-white text-gray-900 shadow focus:outline-none focus:ring-2 focus:ring-orbas-light-blue"
-          />
-          <input
-            type="text"
-            name="phone"
-            id="phone"
-            placeholder="Phone"
-            class="p-4 rounded-lg bg-white text-gray-900 shadow focus:outline-none focus:ring-2 focus:ring-orbas-light-blue md:col-span-2"
-          />
-          <!-- Optional fields to set lead source and owner
-          <input type="hidden" name="lead_source_id" value="1" />
-          <input type="hidden" name="lead_owner_id" value="1" />
-          -->
-          <button
-            type="submit"
-            class="md:col-span-2 btn-primary mt-4"
-          >
-            Submit
-          </button>
-        </form>
+        <div class="max-w-lg mx-auto bg-white text-gray-900 rounded-2xl shadow-2xl p-8">
+          <form id="lead-form" action="https://agency.orbas.io/index.php/collect_leads/save" role="form" method="post" accept-charset="utf-8" class="space-y-4">
+            <input type="text" name="first_name" id="first_name" placeholder="First name" class="w-full p-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-orbas-light-blue" />
+            <input type="text" name="last_name" id="last_name" placeholder="Last name" required class="w-full p-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-orbas-light-blue" />
+            <input type="text" name="company_name" id="company_name" placeholder="Company name" required class="w-full p-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-orbas-light-blue" />
+            <input type="email" name="email" id="email" placeholder="Email" autocomplete="off" class="w-full p-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-orbas-light-blue" />
+            <input type="text" name="phone" id="phone" placeholder="Phone" class="w-full p-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-orbas-light-blue" />
+            <textarea name="address" id="address" rows="3" placeholder="Address" class="w-full p-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-orbas-light-blue"></textarea>
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <input type="text" name="city" id="city" placeholder="City" class="p-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-orbas-light-blue" />
+              <input type="text" name="state" id="state" placeholder="State" class="p-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-orbas-light-blue" />
+            </div>
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <input type="text" name="zip" id="zip" placeholder="Zip" class="p-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-orbas-light-blue" />
+              <input type="text" name="country" id="country" placeholder="Country" class="p-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-orbas-light-blue" />
+            </div>
+            <div class="flex items-start">
+              <input id="privacy" type="checkbox" class="mt-1 mr-2">
+              <label for="privacy" class="text-sm text-gray-700">I agree to the <a href="privacy.html" target="_blank" class="text-orbas-blue underline">privacy policy</a></label>
+            </div>
+            <button id="submit-btn" type="submit" class="btn-primary-sm opacity-50 cursor-not-allowed" disabled>Submit</button>
+          </form>
+          <p id="form-message" class="hidden text-center text-sm text-gray-700 mt-4"></p>
+        </div>
       </div>
     </section>
 
@@ -792,6 +714,30 @@
     </footer>
 
     <script>
+      const privacyCheckbox = document.getElementById('privacy');
+      const submitBtn = document.getElementById('submit-btn');
+      if (privacyCheckbox && submitBtn) {
+        privacyCheckbox.addEventListener('change', () => {
+          submitBtn.disabled = !privacyCheckbox.checked;
+          submitBtn.classList.toggle('opacity-50', !privacyCheckbox.checked);
+          submitBtn.classList.toggle('cursor-not-allowed', !privacyCheckbox.checked);
+        });
+      }
+      const leadForm = document.getElementById('lead-form');
+      if (leadForm) {
+        leadForm.addEventListener('submit', async (e) => {
+          e.preventDefault();
+          const formData = new FormData(leadForm);
+          await fetch(leadForm.action, { method: 'POST', body: formData });
+          const message = document.getElementById('form-message');
+          if (message) {
+            message.textContent = 'Thank you! We will be in touch soon.';
+            message.classList.remove('hidden');
+          }
+          setTimeout(() => { window.location.href = 'index.html'; }, 3000);
+        });
+      }
+
       const menuBtn = document.getElementById("mobile-menu-btn");
       const mobileMenu = document.getElementById("mobile-menu");
       if (menuBtn && mobileMenu) {

--- a/OrbusLanding/index.html
+++ b/OrbusLanding/index.html
@@ -417,11 +417,11 @@
     </section>
 
     <!-- Agency CTA Section -->
-    <section class="py-20 bg-gradient-to-r from-green-500 via-emerald-500 to-teal-500 text-white text-center">
+    <section class="py-20 bg-gradient-to-r from-orbas-blue via-orbas-light-blue to-orbas-dark-blue text-white text-center">
         <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
             <h2 class="text-3xl sm:text-4xl font-bold mb-6">Need a Bespoke Solution?</h2>
             <p class="text-lg mb-8">Our in-house agency builds stunning websites, mobile apps and automations tailored to your goals. Tell us your budget—we’ll craft a package that works for you.</p>
-            <a href="agency.html" class="inline-flex items-center justify-center px-10 py-4 bg-white text-green-700 font-semibold rounded-xl shadow-lg hover:bg-gray-100 transition-all duration-200">
+            <a href="agency.html" class="inline-flex items-center justify-center px-10 py-4 bg-white text-orbas-blue font-semibold rounded-xl shadow-lg hover:bg-gray-100 transition-all duration-200">
                 Learn About Orbas Agency
                 <svg class="ml-3 w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />

--- a/OrbusLanding/privacy.html
+++ b/OrbusLanding/privacy.html
@@ -173,15 +173,10 @@
                 <h3 class="text-2xl font-semibold text-gray-900 mb-4">11. Automated Decision-Making and Profiling</h3>
                 <p class="text-gray-700 mb-6">We do not use your personal data for automated decision-making that produces legal effects. If this changes, we will inform you and explain your rights.</p>
 
-                <h3 class="text-2xl font-semibold text-gray-900 mb-4">10. Data Retention</h3>
-                <p class="text-gray-700 mb-6">
-                    We retain personal data only for as long as necessary to fulfil the purposes described in this policy, comply with legal obligations and resolve disputes.
-                </p>
-                <h3 class="text-2xl font-semibold text-gray-900 mb-4">11. Automated Decision-Making and Profiling</h3>
-                <p class="text-gray-700 mb-6">We do not use your personal data for automated decision-making that produces legal effects. If this changes, we will inform you and explain your rights.</p>
+                <h3 class="text-2xl font-semibold text-gray-900 mb-4">12. Agency Contact Form</h3>
+                <p class="text-gray-700 mb-6">When you submit our agency project form, we collect details such as your name, company and contact information to respond to your enquiry and provide requested services. The lawful bases for this processing are your consent and our legitimate interests in responding to business enquiries. We store submissions securely within the UK, retain them for no longer than 24 months and do not share them outside Orbas except where necessary to deliver our services. You may request access or deletion of your data at any time by emailing <a href="mailto:privacy@orbas.io" class="text-orbas-blue underline">privacy@orbas.io</a>.</p>
 
-
-                <h3 class="text-2xl font-semibold text-gray-900 mb-4">12. Your Rights Under UK GDPR</h3>
+                <h3 class="text-2xl font-semibold text-gray-900 mb-4">13. Your Rights Under UK GDPR</h3>
                 <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
                     <div class="space-y-4">
                         <div class="border border-blue-200 rounded-lg p-4">
@@ -213,7 +208,7 @@
                     </div>
                 </div>
 
-                <h3 class="text-2xl font-semibold text-gray-900 mb-4">13. Contact Information and Complaints</h3>
+                <h3 class="text-2xl font-semibold text-gray-900 mb-4">14. Contact Information and Complaints</h3>
                 <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
                     <div class="bg-gray-50 p-6 rounded-lg">
                         <h4 class="font-medium text-gray-900 mb-4">Data Protection Contacts</h4>
@@ -237,7 +232,7 @@
                     </div>
                 </div>
 
-                <h3 class="text-2xl font-semibold text-gray-900 mb-4">14. Changes to This Policy</h3>
+                <h3 class="text-2xl font-semibold text-gray-900 mb-4">15. Changes to This Policy</h3>
                 <p class="text-gray-700 mb-6">We may update this policy from time to time. Any changes will be posted on this page and, where appropriate, notified to you by email.</p>
 
                 <div class="bg-gray-100 p-6 rounded-lg">


### PR DESCRIPTION
## Summary
- Restyle homepage CTA banner to match Orbas blue theme
- Clean agency hero overlay and redesign lead capture form in a compact card with privacy checkbox and redirect logic
- Expand privacy policy with agency form data handling and correct section numbering

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ff2841848320bbca2180549c4b61