### PR TITLE
Revamp agency form and add hero ticker

### DIFF
--- a/OrbusLanding/agency/index.html
+++ b/OrbusLanding/agency/index.html
@@ -55,10 +55,13 @@
           @apply inline-flex items-center justify-center px-8 py-4 bg-gradient-to-r from-orbas-blue to-orbas-dark-blue text-white font-semibold rounded-xl transition-all duration-200 shadow-lg hover:shadow-xl transform hover:-translate-y-1;
         }
         .btn-primary-sm {
-          @apply w-full inline-flex items-center justify-center px-6 py-3 bg-gradient-to-r from-orbas-blue to-orbas-dark-blue hover:from-orbas-dark-blue hover:to-orbas-blue text-white rounded-lg font-semibold shadow-lg hover:shadow-xl transition-transform transform hover:-translate-y-0.5;
+          @apply w-full inline-flex items-center justify-center px-6 py-3 bg-gradient-to-r from-orbas-dark-blue to-orbas-blue hover:from-orbas-blue hover:to-orbas-dark-blue text-white rounded-lg font-semibold shadow-lg hover:shadow-xl transition-transform transform hover:-translate-y-0.5 disabled:opacity-50 disabled:cursor-not-allowed;
         }
         .badge {
           @apply inline-flex items-center px-4 py-2 rounded-full text-sm font-medium bg-orbas-blue/20 text-orbas-light-blue border border-orbas-light-blue/30;
+        }
+        .form-input {
+          @apply w-full p-3 rounded-lg border-2 border-orbas-dark-blue text-gray-900 placeholder-gray-600 shadow-md focus:outline-none focus:ring-2 focus:ring-orbas-light-blue focus:border-orbas-blue;
         }
       }
     </style>
@@ -70,7 +73,7 @@
         <div class="flex justify-between items-center h-16">
           <!-- Logo -->
           <div class="flex items-center">
-            <a href="index.html">
+            <a href="/">
               <img
                 src="https://i.ibb.co/gLcRkc8k/IMG-2726-removebg-preview.png"
                 alt="Orbas Logo"
@@ -82,32 +85,32 @@
           <!-- Navigation -->
           <nav class="hidden md:flex space-x-8">
             <a
-              href="index.html#about"
+              href="/#about"
               class="text-gray-600 hover:text-orbas-blue font-medium transition-colors"
               >About</a
             >
             <a
-              href="index.html#platforms"
+              href="/#platforms"
               class="text-gray-600 hover:text-orbas-blue font-medium transition-colors"
               >Platforms</a
             >
             <a
-              href="agency.html"
+              href="/agency"
               class="text-gray-600 hover:text-orbas-blue font-medium transition-colors"
               >Agency</a
             >
             <a
-              href="investors.html"
+              href="/investors"
               class="text-gray-600 hover:text-orbas-blue font-medium transition-colors"
               >Investors</a
             >
             <a
-              href="index.html#contact"
+              href="/#contact"
               class="text-gray-600 hover:text-orbas-blue font-medium transition-colors"
               >Contact</a
             >
             <a
-              href="privacy.html"
+              href="/privacy"
               class="text-gray-600 hover:text-orbas-blue font-medium transition-colors"
               >Privacy</a
             >
@@ -143,29 +146,29 @@
     >
       <nav class="space-y-4 text-center text-lg font-medium">
         <a
-          href="index.html#about"
+          href="/#about"
           class="block text-gray-600 hover:text-orbas-blue"
           >About</a
         >
         <a
-          href="index.html#platforms"
+          href="/#platforms"
           class="block text-gray-600 hover:text-orbas-blue"
           >Platforms</a
         >
-        <a href="agency.html" class="block text-gray-600 hover:text-orbas-blue"
+        <a href="/agency" class="block text-gray-600 hover:text-orbas-blue"
           >Agency</a
         >
         <a
-          href="investors.html"
+          href="/investors"
           class="block text-gray-600 hover:text-orbas-blue"
           >Investors</a
         >
         <a
-          href="index.html#contact"
+          href="/#contact"
           class="block text-gray-600 hover:text-orbas-blue"
           >Contact</a
         >
-        <a href="privacy.html" class="block text-gray-600 hover:text-orbas-blue"
+        <a href="/privacy" class="block text-gray-600 hover:text-orbas-blue"
           >Privacy</a
         >
       </nav>
@@ -502,27 +505,27 @@
         </p>
         <div class="max-w-lg mx-auto bg-white text-gray-900 rounded-2xl shadow-2xl p-8">
           <form id="lead-form" action="https://agency.orbas.io/index.php/collect_leads/save" role="form" method="post" accept-charset="utf-8" class="space-y-4">
-            <input type="text" name="first_name" id="first_name" placeholder="First name" class="w-full p-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-orbas-light-blue" />
-            <input type="text" name="last_name" id="last_name" placeholder="Last name" required class="w-full p-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-orbas-light-blue" />
-            <input type="text" name="company_name" id="company_name" placeholder="Company name" required class="w-full p-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-orbas-light-blue" />
-            <input type="email" name="email" id="email" placeholder="Email" autocomplete="off" class="w-full p-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-orbas-light-blue" />
-            <input type="text" name="phone" id="phone" placeholder="Phone" class="w-full p-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-orbas-light-blue" />
-            <textarea name="address" id="address" rows="3" placeholder="Address" class="w-full p-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-orbas-light-blue"></textarea>
+            <input type="text" name="first_name" id="first_name" placeholder="First name" class="form-input" />
+            <input type="text" name="last_name" id="last_name" placeholder="Last name" required class="form-input" />
+            <input type="text" name="company_name" id="company_name" placeholder="Company name" required class="form-input" />
+            <input type="email" name="email" id="email" placeholder="Email" autocomplete="off" class="form-input" />
+            <input type="text" name="phone" id="phone" placeholder="Phone" class="form-input" />
+            <textarea name="address" id="address" rows="3" placeholder="Address" class="form-input"></textarea>
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <input type="text" name="city" id="city" placeholder="City" class="p-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-orbas-light-blue" />
-              <input type="text" name="state" id="state" placeholder="State" class="p-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-orbas-light-blue" />
+              <input type="text" name="city" id="city" placeholder="City" class="form-input" />
+              <input type="text" name="state" id="state" placeholder="State" class="form-input" />
             </div>
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <input type="text" name="zip" id="zip" placeholder="Zip" class="p-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-orbas-light-blue" />
-              <input type="text" name="country" id="country" placeholder="Country" class="p-3 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-orbas-light-blue" />
+              <input type="text" name="zip" id="zip" placeholder="Zip" class="form-input" />
+              <input type="text" name="country" id="country" placeholder="Country" class="form-input" />
             </div>
             <div class="flex items-start">
               <input id="privacy" type="checkbox" class="mt-1 mr-2">
-              <label for="privacy" class="text-sm text-gray-700">I agree to the <a href="privacy.html" target="_blank" class="text-orbas-blue underline">privacy policy</a></label>
+              <label for="privacy" class="text-sm text-gray-900">I agree to the <a href="/privacy" target="_blank" class="text-orbas-blue underline">privacy policy</a></label>
             </div>
-            <button id="submit-btn" type="submit" class="btn-primary-sm opacity-50 cursor-not-allowed" disabled>Submit</button>
+            <button id="submit-btn" type="submit" class="btn-primary-sm" disabled>Submit</button>
           </form>
-          <p id="form-message" class="hidden text-center text-sm text-gray-700 mt-4"></p>
+          <p id="form-message" class="hidden text-center text-sm text-gray-900 mt-4"></p>
         </div>
       </div>
     </section>
@@ -646,26 +649,26 @@
             <ul class="space-y-4 text-gray-700">
               <li>
                 <a
-                  href="index.html#about"
+                  href="/#about"
                   class="hover:text-black transition-colors"
                   >About Orbas</a
                 >
               </li>
               <li>
-                <a href="agency.html" class="hover:text-black transition-colors"
+                <a href="/agency" class="hover:text-black transition-colors"
                   >Orbas Agency</a
                 >
               </li>
               <li>
                 <a
-                  href="investors.html"
+                  href="/investors"
                   class="hover:text-black transition-colors"
                   >Investors</a
                 >
               </li>
               <li>
                 <a
-                  href="privacy.html"
+                  href="/privacy"
                   class="hover:text-black transition-colors"
                   >Privacy Policy</a
                 >
@@ -719,8 +722,6 @@
       if (privacyCheckbox && submitBtn) {
         privacyCheckbox.addEventListener('change', () => {
           submitBtn.disabled = !privacyCheckbox.checked;
-          submitBtn.classList.toggle('opacity-50', !privacyCheckbox.checked);
-          submitBtn.classList.toggle('cursor-not-allowed', !privacyCheckbox.checked);
         });
       }
       const leadForm = document.getElementById('lead-form');
@@ -734,7 +735,7 @@
             message.textContent = 'Thank you! We will be in touch soon.';
             message.classList.remove('hidden');
           }
-          setTimeout(() => { window.location.href = 'index.html'; }, 3000);
+          setTimeout(() => { window.location.href = '/'; }, 3000);
         });
       }
 

--- a/OrbusLanding/index.html
+++ b/OrbusLanding/index.html
@@ -18,7 +18,7 @@
     
     <!-- Tailwind CSS -->
     <script src="https://cdn.tailwindcss.com"></script>
-    
+
     <!-- Custom Tailwind Config -->
     <script>
         tailwind.config = {
@@ -41,6 +41,15 @@
             }
         }
     </script>
+    <style>
+        @keyframes ticker {
+            0% { transform: translateX(-100%); }
+            100% { transform: translateX(100%); }
+        }
+        .ticker-animation {
+            animation: ticker 40s linear infinite;
+        }
+    </style>
 </head>
 <body class="bg-white text-gray-900 font-poppins antialiased">
     <!-- Header Navigation -->
@@ -49,7 +58,7 @@
             <div class="flex justify-between items-center h-16">
                 <!-- Logo -->
                 <div class="flex items-center">
-                    <a href="index.html">
+                    <a href="/">
                         <img src="https://i.ibb.co/gLcRkc8k/IMG-2726-removebg-preview.png" alt="Orbas Logo" class="h-12 w-auto">
                     </a>
                 </div>
@@ -58,10 +67,10 @@
                 <nav class="hidden md:flex space-x-8">
                     <a href="#about" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">About</a>
                     <a href="#platforms" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Platforms</a>
-                    <a href="agency.html" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Agency</a>
-                    <a href="investors.html" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Investors</a>
+                    <a href="agency" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Agency</a>
+                    <a href="investors" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Investors</a>
                     <a href="#contact" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Contact</a>
-                    <a href="privacy.html" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Privacy</a>
+                    <a href="privacy" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Privacy</a>
                 </nav>
                 <!-- Mobile menu button -->
                 <button id="mobile-menu-btn" class="md:hidden text-gray-600 hover:text-orbas-blue focus:outline-none">
@@ -77,10 +86,10 @@
     <nav class="space-y-4 text-center text-lg font-medium">
         <a href="#about" class="block text-gray-600 hover:text-orbas-blue">About</a>
         <a href="#platforms" class="block text-gray-600 hover:text-orbas-blue">Platforms</a>
-        <a href="agency.html" class="block text-gray-600 hover:text-orbas-blue">Agency</a>
-        <a href="investors.html" class="block text-gray-600 hover:text-orbas-blue">Investors</a>
+        <a href="agency" class="block text-gray-600 hover:text-orbas-blue">Agency</a>
+        <a href="investors" class="block text-gray-600 hover:text-orbas-blue">Investors</a>
         <a href="#contact" class="block text-gray-600 hover:text-orbas-blue">Contact</a>
-        <a href="privacy.html" class="block text-gray-600 hover:text-orbas-blue">Privacy</a>
+        <a href="privacy" class="block text-gray-600 hover:text-orbas-blue">Privacy</a>
     </nav>
 </div>
 
@@ -124,7 +133,7 @@
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
                             </svg>
                         </a>
-                        <a href="agency.html" class="inline-flex items-center justify-center px-8 py-4 bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white font-semibold rounded-xl transition-all duration-200 shadow-lg hover:shadow-xl transform hover:-translate-y-1">
+                        <a href="agency" class="inline-flex items-center justify-center px-8 py-4 bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white font-semibold rounded-xl transition-all duration-200 shadow-lg hover:shadow-xl transform hover:-translate-y-1">
                             Work with Our Agency
                             <svg class="ml-2 w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
@@ -150,6 +159,18 @@
                     <div class="absolute -top-4 -right-4 w-20 h-20 bg-gradient-to-br from-purple-400 to-pink-500 rounded-full opacity-60 animate-bounce"></div>
                     <div class="absolute -bottom-4 -left-4 w-16 h-16 bg-gradient-to-br from-blue-400 to-cyan-500 rounded-full opacity-40 animate-bounce"></div>
                 </div>
+            </div>
+        </div>
+        <div class="absolute bottom-0 left-0 w-full bg-red-600 text-white overflow-hidden">
+            <div class="ticker flex whitespace-nowrap ticker-animation">
+                <div class="px-8 flex items-center text-right">Orbas AI: Out Now!</div>
+                <div class="px-8 flex items-center text-right">Orbas Freelance: Upgrading All Systems <span class="countdown mx-2" data-end="2025-09-16T00:00:00Z"></span><span class="end-date">(16/09/2025)</span></div>
+                <div class="px-8 flex items-center text-right">Orbas Learn: Upgrading All Systems <span class="countdown mx-2" data-end="2025-09-18T00:00:00Z"></span><span class="end-date">(18/09/2025)</span></div>
+                <div class="px-8 flex items-center text-right">Orbas Services: Upgrading All Systems <span class="countdown mx-2" data-end="2025-09-17T00:00:00Z"></span><span class="end-date">(17/09/2025)</span></div>
+                <div class="px-8 flex items-center text-right">Orbas AI: Out Now!</div>
+                <div class="px-8 flex items-center text-right">Orbas Freelance: Upgrading All Systems <span class="countdown mx-2" data-end="2025-09-16T00:00:00Z"></span><span class="end-date">(16/09/2025)</span></div>
+                <div class="px-8 flex items-center text-right">Orbas Learn: Upgrading All Systems <span class="countdown mx-2" data-end="2025-09-18T00:00:00Z"></span><span class="end-date">(18/09/2025)</span></div>
+                <div class="px-8 flex items-center text-right">Orbas Services: Upgrading All Systems <span class="countdown mx-2" data-end="2025-09-17T00:00:00Z"></span><span class="end-date">(17/09/2025)</span></div>
             </div>
         </div>
     </section>
@@ -421,7 +442,7 @@
         <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
             <h2 class="text-3xl sm:text-4xl font-bold mb-6">Need a Bespoke Solution?</h2>
             <p class="text-lg mb-8">Our in-house agency builds stunning websites, mobile apps and automations tailored to your goals. Tell us your budget—we’ll craft a package that works for you.</p>
-            <a href="agency.html" class="inline-flex items-center justify-center px-10 py-4 bg-white text-orbas-blue font-semibold rounded-xl shadow-lg hover:bg-gray-100 transition-all duration-200">
+            <a href="agency" class="inline-flex items-center justify-center px-10 py-4 bg-white text-orbas-blue font-semibold rounded-xl shadow-lg hover:bg-gray-100 transition-all duration-200">
                 Learn About Orbas Agency
                 <svg class="ml-3 w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
@@ -473,7 +494,7 @@
                         </svg>
                     </div>
                     <h3 class="font-semibold text-gray-900 mb-2">Privacy</h3>
-                    <a href="privacy.html" class="text-orbas-blue hover:text-orbas-dark-blue font-medium">Privacy Policy</a>
+                    <a href="privacy" class="text-orbas-blue hover:text-orbas-dark-blue font-medium">Privacy Policy</a>
                     <br>
                     <a href="mailto:privacy@orbas.io" class="text-gray-600 hover:text-gray-800">privacy@orbas.io</a>
                 </div>
@@ -561,12 +582,12 @@
                             </a>
                         </li>
                         <li>
-                            <a href="agency.html" class="hover:text-black transition-colors">
+                            <a href="agency" class="hover:text-black transition-colors">
                                 Orbas Agency
                             </a>
                         </li>
                         <li>
-                            <a href="investors.html" class="hover:text-black transition-colors">
+                            <a href="investors" class="hover:text-black transition-colors">
                                 Investors
                             </a>
                         </li>
@@ -576,7 +597,7 @@
                             </a>
                         </li>
                         <li>
-                            <a href="privacy.html" class="hover:text-black transition-colors">
+                            <a href="privacy" class="hover:text-black transition-colors">
                                 Privacy Policy
                             </a>
                         </li>
@@ -616,6 +637,32 @@
           link.addEventListener("click", () => mobileMenu.classList.add("hidden"));
         });
       }
+    </script>
+    <script>
+      document.querySelectorAll('.countdown').forEach(el => {
+        const end = new Date(el.dataset.end);
+        const update = () => {
+          const now = new Date();
+          let diff = end - now;
+          if (diff <= 0) {
+            el.innerHTML = 'Out Now!';
+            const dateEl = el.nextElementSibling;
+            if (dateEl) dateEl.remove();
+            return;
+          }
+          const pad = n => String(n).padStart(2, '0');
+          const days = Math.floor(diff / 86400000);
+          diff %= 86400000;
+          const hours = Math.floor(diff / 3600000);
+          diff %= 3600000;
+          const mins = Math.floor(diff / 60000);
+          diff %= 60000;
+          const secs = Math.floor(diff / 1000);
+          el.innerHTML = `${days}d<span class="mx-1 animate-pulse">:</span>${pad(hours)}h<span class="mx-1 animate-pulse">:</span>${pad(mins)}m<span class="mx-1 animate-pulse">:</span>${pad(secs)}s`;
+        };
+        update();
+        setInterval(update, 1000);
+      });
     </script>
     <!-- Chatwoot -->
     <script>

--- a/OrbusLanding/investors/index.html
+++ b/OrbusLanding/investors/index.html
@@ -39,17 +39,17 @@
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex justify-between items-center h-16">
                 <div class="flex items-center">
-                    <a href="index.html">
+                    <a href="/">
                         <img src="https://i.ibb.co/gLcRkc8k/IMG-2726-removebg-preview.png" alt="Orbas Logo" class="h-12 w-auto">
                     </a>
                 </div>
                 <nav class="hidden md:flex space-x-8">
-                    <a href="index.html#about" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">About</a>
-                    <a href="index.html#platforms" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Platforms</a>
-                    <a href="agency.html" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Agency</a>
-                    <a href="investors.html" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Investors</a>
-                    <a href="index.html#contact" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Contact</a>
-                    <a href="privacy.html" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Privacy</a>
+                    <a href="/#about" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">About</a>
+                    <a href="/#platforms" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Platforms</a>
+                    <a href="/agency" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Agency</a>
+                    <a href="/investors" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Investors</a>
+                    <a href="/#contact" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Contact</a>
+                    <a href="/privacy" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Privacy</a>
                 </nav>
 
                 <!-- Mobile menu button -->
@@ -65,12 +65,12 @@
     <!-- Mobile Menu -->
     <div id="mobile-menu" class="md:hidden hidden fixed top-16 left-0 right-0 z-40 px-6 py-6 bg-white/90 backdrop-blur-lg shadow-xl border-b border-gray-200 rounded-b-xl">
         <nav class="space-y-4 text-center text-lg font-medium">
-            <a href="index.html#about" class="block text-gray-600 hover:text-orbas-blue">About</a>
-            <a href="index.html#platforms" class="block text-gray-600 hover:text-orbas-blue">Platforms</a>
-            <a href="agency.html" class="block text-gray-600 hover:text-orbas-blue">Agency</a>
-            <a href="investors.html" class="block text-gray-600 hover:text-orbas-blue">Investors</a>
-            <a href="index.html#contact" class="block text-gray-600 hover:text-orbas-blue">Contact</a>
-            <a href="privacy.html" class="block text-gray-600 hover:text-orbas-blue">Privacy</a>
+            <a href="/#about" class="block text-gray-600 hover:text-orbas-blue">About</a>
+            <a href="/#platforms" class="block text-gray-600 hover:text-orbas-blue">Platforms</a>
+            <a href="/agency" class="block text-gray-600 hover:text-orbas-blue">Agency</a>
+            <a href="/investors" class="block text-gray-600 hover:text-orbas-blue">Investors</a>
+            <a href="/#contact" class="block text-gray-600 hover:text-orbas-blue">Contact</a>
+            <a href="/privacy" class="block text-gray-600 hover:text-orbas-blue">Privacy</a>
         </nav>
     </div>
 
@@ -196,10 +196,10 @@
                 <div>
                     <h4 class="text-lg font-bold mb-6 text-black">Company</h4>
                     <ul class="space-y-4 text-gray-700">
-                        <li><a href="index.html#about" class="hover:text-black transition-colors">About Orbas</a></li>
-                        <li><a href="agency.html" class="hover:text-black transition-colors">Orbas Agency</a></li>
-                        <li><a href="investors.html" class="hover:text-black transition-colors">Investors</a></li>
-                        <li><a href="privacy.html" class="hover:text-black transition-colors">Privacy Policy</a></li>
+                        <li><a href="/#about" class="hover:text-black transition-colors">About Orbas</a></li>
+                        <li><a href="/agency" class="hover:text-black transition-colors">Orbas Agency</a></li>
+                        <li><a href="/investors" class="hover:text-black transition-colors">Investors</a></li>
+                        <li><a href="/privacy" class="hover:text-black transition-colors">Privacy Policy</a></li>
                     </ul>
                 </div>
             </div>

--- a/OrbusLanding/privacy/index.html
+++ b/OrbusLanding/privacy/index.html
@@ -47,19 +47,19 @@
             <div class="flex justify-between items-center h-16">
                 <!-- Logo -->
                 <div class="flex items-center">
-                    <a href="index.html">
+                    <a href="/">
                         <img src="https://i.ibb.co/gLcRkc8k/IMG-2726-removebg-preview.png" alt="Orbas Logo" class="h-12 w-auto">
                     </a>
                 </div>
 
                 <!-- Navigation -->
                 <nav class="hidden md:flex space-x-8">
-                    <a href="index.html#about" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">About</a>
-                    <a href="index.html#platforms" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Platforms</a>
-                    <a href="agency.html" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Agency</a>
-                    <a href="investors.html" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Investors</a>
-                    <a href="index.html#contact" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Contact</a>
-                    <a href="privacy.html" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Privacy</a>
+                    <a href="/#about" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">About</a>
+                    <a href="/#platforms" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Platforms</a>
+                    <a href="/agency" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Agency</a>
+                    <a href="/investors" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Investors</a>
+                    <a href="/#contact" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Contact</a>
+                    <a href="/privacy" class="text-gray-600 hover:text-orbas-blue font-medium transition-colors">Privacy</a>
                 </nav>
 
                 <!-- Mobile menu button -->
@@ -75,12 +75,12 @@
     <!-- Mobile Menu -->
     <div id="mobile-menu" class="md:hidden hidden fixed top-16 left-0 right-0 z-40 px-6 py-6 bg-white/90 backdrop-blur-lg shadow-xl border-b border-gray-200 rounded-b-xl">
         <nav class="space-y-4 text-center text-lg font-medium">
-            <a href="index.html#about" class="block text-gray-600 hover:text-orbas-blue">About</a>
-            <a href="index.html#platforms" class="block text-gray-600 hover:text-orbas-blue">Platforms</a>
-            <a href="agency.html" class="block text-gray-600 hover:text-orbas-blue">Agency</a>
-            <a href="investors.html" class="block text-gray-600 hover:text-orbas-blue">Investors</a>
-            <a href="index.html#contact" class="block text-gray-600 hover:text-orbas-blue">Contact</a>
-            <a href="privacy.html" class="block text-gray-600 hover:text-orbas-blue">Privacy</a>
+            <a href="/#about" class="block text-gray-600 hover:text-orbas-blue">About</a>
+            <a href="/#platforms" class="block text-gray-600 hover:text-orbas-blue">Platforms</a>
+            <a href="/agency" class="block text-gray-600 hover:text-orbas-blue">Agency</a>
+            <a href="/investors" class="block text-gray-600 hover:text-orbas-blue">Investors</a>
+            <a href="/#contact" class="block text-gray-600 hover:text-orbas-blue">Contact</a>
+            <a href="/privacy" class="block text-gray-600 hover:text-orbas-blue">Privacy</a>
         </nav>
     </div>
 
@@ -329,17 +329,17 @@
                             </a>
                         </li>
                         <li>
-                            <a href="agency.html" class="hover:text-black transition-colors">
+                            <a href="/agency" class="hover:text-black transition-colors">
                                 Orbas Agency
                             </a>
                         </li>
                         <li>
-                            <a href="investors.html" class="hover:text-black transition-colors">
+                            <a href="/investors" class="hover:text-black transition-colors">
                                 Investors
                             </a>
                         </li>
                         <li>
-                            <a href="privacy.html" class="hover:text-black transition-colors">
+                            <a href="/privacy" class="hover:text-black transition-colors">
                                 Privacy Policy
                             </a>
                         </li>


### PR DESCRIPTION
## Summary
- Improve agency contact form with dark borders, shadows, and disabled button styling.
- Remove `.html` extensions from all internal links for cleaner routes.
- Add red carousel ticker with countdown timers to home hero section.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b102a3f3c483208d4d98b464ac771c