### PR TITLE
Add animated node backgrounds and glass UI elements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/OrbusLanding/agency/index.html
+++ b/OrbusLanding/agency/index.html
@@ -53,16 +53,16 @@
     <style type="text/tailwindcss">
       @layer components {
         .btn-primary {
-          @apply inline-flex items-center justify-center px-8 py-4 bg-gradient-to-r from-orbas-blue to-orbas-dark-blue text-white font-semibold rounded-xl transition-all duration-200 shadow-lg hover:shadow-xl transform hover:-translate-y-1;
+          @apply inline-flex items-center justify-center px-8 py-4 bg-gradient-to-r from-orbas-blue/80 to-orbas-dark-blue/80 hover:from-orbas-dark-blue/80 hover:to-orbas-blue/80 text-white font-semibold rounded-xl transition-all duration-200 shadow-lg hover:shadow-xl transform hover:-translate-y-1 backdrop-blur-md border border-white/20;
         }
         .btn-primary-sm {
-          @apply w-full inline-flex items-center justify-center px-6 py-3 bg-gradient-to-r from-orbas-dark-blue to-orbas-blue hover:from-orbas-blue hover:to-orbas-dark-blue text-white rounded-lg font-semibold shadow-lg hover:shadow-xl transition-transform transform hover:-translate-y-0.5 disabled:opacity-50 disabled:cursor-not-allowed;
+          @apply w-full inline-flex items-center justify-center px-6 py-3 bg-gradient-to-r from-orbas-dark-blue/80 to-orbas-blue/80 hover:from-orbas-blue/80 hover:to-orbas-dark-blue/80 text-white rounded-lg font-semibold shadow-lg hover:shadow-xl transition-transform transform hover:-translate-y-0.5 disabled:opacity-50 disabled:cursor-not-allowed backdrop-blur-md border border-white/20;
         }
         .badge {
           @apply inline-flex items-center px-4 py-2 rounded-full text-sm font-medium bg-orbas-blue/20 text-orbas-light-blue border border-orbas-light-blue/30;
         }
         .form-input {
-          @apply w-full p-3 rounded-lg border-2 border-orbas-dark-blue text-gray-900 placeholder-gray-600 shadow-md focus:outline-none focus:ring-2 focus:ring-orbas-light-blue focus:border-orbas-blue;
+          @apply w-full p-3 rounded-lg border border-white/20 bg-white/10 text-white placeholder-gray-200 shadow-md backdrop-blur-md focus:outline-none focus:ring-2 focus:ring-orbas-light-blue focus:border-orbas-blue;
         }
       }
     </style>
@@ -179,6 +179,7 @@
     <section
       class="relative bg-gradient-to-br from-gray-900 via-orbas-dark-blue to-orbas-blue py-32 px-4 sm:px-6 lg:px-8 overflow-hidden"
     >
+      <canvas id="agency-hero-canvas" class="absolute inset-0 w-full h-full pointer-events-none"></canvas>
       <div class="absolute inset-0 bg-black/20"></div>
       <div
         class="relative max-w-7xl mx-auto grid grid-cols-1 lg:grid-cols-2 gap-16 items-center"
@@ -498,7 +499,7 @@
         <p class="text-lg text-center mb-12 text-gray-100">
           Share a few details and our team will reach out shortly.
         </p>
-        <div class="max-w-lg mx-auto bg-white text-gray-900 rounded-2xl shadow-2xl p-8">
+        <div class="max-w-lg mx-auto bg-white/10 backdrop-blur-md text-white rounded-2xl shadow-2xl p-8 border border-white/20">
           <form id="lead-form" action="https://agency.orbas.io/index.php/collect_leads/save" role="form" method="post" accept-charset="utf-8" class="space-y-4">
             <input type="text" name="first_name" id="first_name" placeholder="First name" class="form-input" />
             <input type="text" name="last_name" id="last_name" placeholder="Last name" required class="form-input" />
@@ -516,11 +517,11 @@
             </div>
             <div class="flex items-start">
               <input id="privacy" type="checkbox" class="mt-1 mr-2">
-              <label for="privacy" class="text-sm text-gray-900">I agree to the <a href="/privacy" target="_blank" class="text-orbas-blue underline">privacy policy</a></label>
+              <label for="privacy" class="text-sm text-white">I agree to the <a href="/privacy" target="_blank" class="text-orbas-blue underline">privacy policy</a></label>
             </div>
             <button id="submit-btn" type="submit" class="btn-primary-sm" disabled>Submit</button>
           </form>
-          <p id="form-message" class="hidden text-center text-sm text-gray-900 mt-4"></p>
+          <p id="form-message" class="hidden text-center text-sm text-white mt-4"></p>
         </div>
       </div>
     </section>
@@ -751,6 +752,15 @@
     </script>
 
     <!-- Chatwoot -->
+    <script src="../hero-nodes.js"></script>
+    <script>
+      initHeroNodes('agency-hero-canvas', {
+        nodeColor: '#3b82f6',
+        lineColor: 'rgba(59,130,246,0.3)',
+        nodeCount: 70,
+        connectionDistance: 150
+      });
+    </script>
     <script>
       (function (d, t) {
         var BASE_URL = "https://support.orbas.io";

--- a/OrbusLanding/hero-nodes.js
+++ b/OrbusLanding/hero-nodes.js
@@ -1,0 +1,75 @@
+function initHeroNodes(id, opts = {}) {
+  const canvas = document.getElementById(id);
+  if (!canvas) return;
+  const ctx = canvas.getContext('2d');
+  const config = Object.assign({
+    nodeColor: '#ffffff',
+    lineColor: 'rgba(255,255,255,0.2)',
+    nodeCount: 40,
+    nodeSize: 3,
+    lineWidth: 1,
+    maxVelocity: 0.4,
+    connectionDistance: 150
+  }, opts);
+
+  let nodes = [];
+  const dpr = window.devicePixelRatio || 1;
+
+  function resize() {
+    const { offsetWidth, offsetHeight } = canvas;
+    canvas.width = offsetWidth * dpr;
+    canvas.height = offsetHeight * dpr;
+    canvas.style.width = offsetWidth + 'px';
+    canvas.style.height = offsetHeight + 'px';
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    nodes = Array.from({ length: config.nodeCount }, () => ({
+      x: Math.random() * offsetWidth,
+      y: Math.random() * offsetHeight,
+      vx: (Math.random() - 0.5) * config.maxVelocity,
+      vy: (Math.random() - 0.5) * config.maxVelocity
+    }));
+  }
+
+  window.addEventListener('resize', resize);
+  resize();
+
+  function draw() {
+    const width = canvas.width / dpr;
+    const height = canvas.height / dpr;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    for (const n of nodes) {
+      n.x += n.vx;
+      n.y += n.vy;
+      if (n.x <= 0 || n.x >= width) n.vx *= -1;
+      if (n.y <= 0 || n.y >= height) n.vy *= -1;
+
+      ctx.beginPath();
+      ctx.arc(n.x, n.y, config.nodeSize, 0, Math.PI * 2);
+      ctx.fillStyle = config.nodeColor;
+      ctx.fill();
+    }
+
+    for (let i = 0; i < nodes.length; i++) {
+      for (let j = i + 1; j < nodes.length; j++) {
+        const a = nodes[i];
+        const b = nodes[j];
+        const dist = Math.hypot(a.x - b.x, a.y - b.y);
+        if (dist < config.connectionDistance) {
+          ctx.strokeStyle = config.lineColor;
+          ctx.lineWidth = config.lineWidth;
+          ctx.globalAlpha = 1 - dist / config.connectionDistance;
+          ctx.beginPath();
+          ctx.moveTo(a.x, a.y);
+          ctx.lineTo(b.x, b.y);
+          ctx.stroke();
+          ctx.globalAlpha = 1;
+        }
+      }
+    }
+
+    requestAnimationFrame(draw);
+  }
+
+  draw();
+}

--- a/OrbusLanding/index.html
+++ b/OrbusLanding/index.html
@@ -63,6 +63,7 @@
 
     <!-- Hero Section -->
     <section class="relative bg-gradient-to-br from-gray-900 via-blue-900 to-purple-900 py-32 px-4 sm:px-6 lg:px-8 overflow-hidden">
+        <canvas id="home-hero-canvas" class="absolute inset-0 w-full h-full pointer-events-none"></canvas>
         <!-- Background overlay -->
         <div class="absolute inset-0 bg-black/20"></div>
         
@@ -89,19 +90,19 @@
                     </p>
                     
                     <div class="flex flex-col sm:flex-row gap-6">
-                        <a href="#platforms" class="inline-flex items-center justify-center px-8 py-4 bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white font-semibold rounded-xl transition-all duration-200 shadow-lg hover:shadow-xl transform hover:-translate-y-1">
+                        <a href="#platforms" class="inline-flex items-center justify-center px-8 py-4 bg-gradient-to-r from-blue-600/80 to-purple-600/80 hover:from-blue-700/80 hover:to-purple-700/80 text-white font-semibold rounded-xl transition-all duration-200 shadow-lg hover:shadow-xl transform hover:-translate-y-1 backdrop-blur-md border border-white/20">
                             Explore Platforms
                             <svg class="ml-2 w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
                             </svg>
                         </a>
-                        <a href="#contact" class="inline-flex items-center justify-center px-8 py-4 bg-white/10 hover:bg-white/20 text-white font-semibold rounded-xl transition-all duration-200 shadow-lg hover:shadow-xl transform hover:-translate-y-1">
+                        <a href="#contact" class="inline-flex items-center justify-center px-8 py-4 bg-white/10 hover:bg-white/20 text-white font-semibold rounded-xl transition-all duration-200 shadow-lg hover:shadow-xl transform hover:-translate-y-1 backdrop-blur-md border border-white/20">
                             Contact Sales
                             <svg class="ml-2 w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
                             </svg>
                         </a>
-                        <a href="agency" class="inline-flex items-center justify-center px-8 py-4 bg-gradient-to-r from-green-500 to-emerald-600 hover:from-green-600 hover:to-emerald-700 text-white font-semibold rounded-xl transition-all duration-200 shadow-lg hover:shadow-xl transform hover:-translate-y-1">
+                        <a href="agency" class="inline-flex items-center justify-center px-8 py-4 bg-gradient-to-r from-green-500/80 to-emerald-600/80 hover:from-green-600/80 hover:to-emerald-700/80 text-white font-semibold rounded-xl transition-all duration-200 shadow-lg hover:shadow-xl transform hover:-translate-y-1 backdrop-blur-md border border-white/20">
                             Work with Our Agency
                             <svg class="ml-2 w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
@@ -472,6 +473,15 @@
 
     <!-- Footer -->
     <div id="footer"></div>
+    <script src="hero-nodes.js"></script>
+    <script>
+      initHeroNodes('home-hero-canvas', {
+        nodeColor: '#60a5fa',
+        lineColor: 'rgba(96,165,250,0.3)',
+        nodeCount: 80,
+        connectionDistance: 160
+      });
+    </script>
     <script src="/layout.js"></script>
     <script>
       document.querySelectorAll('.countdown').forEach(el => {

--- a/OrbusLanding/investors/index.html
+++ b/OrbusLanding/investors/index.html
@@ -76,7 +76,8 @@
     </div>
 
     <section class="relative isolate overflow-hidden bg-gradient-to-br from-blue-950 via-indigo-900 to-purple-900 py-32 px-4 sm:px-6 lg:px-8">
-        <div class="absolute inset-0 -z-10">
+        <canvas id="investor-hero-canvas" class="absolute inset-0 w-full h-full pointer-events-none"></canvas>
+        <div class="absolute inset-0 pointer-events-none">
             <div class="absolute -top-24 -left-24 w-96 h-96 bg-orbas-blue/40 blur-3xl rounded-full"></div>
             <div class="absolute bottom-0 right-0 w-80 h-80 bg-orbas-purple/40 blur-2xl rounded-full"></div>
         </div>
@@ -85,8 +86,8 @@
                 <h1 class="text-4xl sm:text-6xl font-extrabold text-white mb-6 leading-tight">Invest in Orbas</h1>
                 <p class="text-lg sm:text-xl text-gray-200 mb-10 leading-relaxed">Join us as we reshape global professional services with AI, planned blockchain integration and 24/7 automation.</p>
                 <div class="flex flex-col sm:flex-row gap-6 justify-center lg:justify-start">
-                    <a href="mailto:support@orbas.io" class="inline-flex items-center justify-center px-8 py-4 bg-orbas-blue text-white font-semibold rounded-xl shadow-lg hover:bg-orbas-dark-blue transition-all">Contact Investor Relations</a>
-                    <a href="#vision" class="inline-flex items-center justify-center px-8 py-4 border border-white/30 text-white font-semibold rounded-xl hover:bg-white/10 transition-all">Our Vision</a>
+                    <a href="mailto:support@orbas.io" class="inline-flex items-center justify-center px-8 py-4 bg-orbas-blue/80 hover:bg-orbas-dark-blue/80 text-white font-semibold rounded-xl shadow-lg transition-all backdrop-blur-md border border-white/20">Contact Investor Relations</a>
+                    <a href="#vision" class="inline-flex items-center justify-center px-8 py-4 border border-white/30 text-white font-semibold rounded-xl hover:bg-white/10 transition-all backdrop-blur-md bg-white/5">Our Vision</a>
                 </div>
             </div>
             <div class="relative">
@@ -143,8 +144,8 @@
             <h2 class="text-3xl sm:text-4xl font-bold mb-6">Be Part of the Journey</h2>
             <p class="text-lg mb-8">We're preparing an investor brief outlining our roadmap and funding plans. Reach out to explore how we can grow together.</p>
             <div class="flex flex-col sm:flex-row gap-6 justify-center">
-                <a href="mailto:support@orbas.io" class="inline-flex items-center justify-center px-8 py-4 bg-white text-blue-700 font-semibold rounded-xl shadow-lg hover:bg-gray-100 transition-all">Request Investor Brief</a>
-                <a href="mailto:support@orbas.io?subject=Schedule%20a%20Call" class="inline-flex items-center justify-center px-8 py-4 bg-white/10 hover:bg-white/20 text-white font-semibold rounded-xl transition-all">Schedule a Call</a>
+                <a href="mailto:support@orbas.io" class="inline-flex items-center justify-center px-8 py-4 bg-white/20 hover:bg-white/30 text-blue-700 font-semibold rounded-xl shadow-lg transition-all backdrop-blur-md border border-white/20">Request Investor Brief</a>
+                <a href="mailto:support@orbas.io?subject=Schedule%20a%20Call" class="inline-flex items-center justify-center px-8 py-4 bg-white/10 hover:bg-white/20 text-white font-semibold rounded-xl transition-all backdrop-blur-md border border-white/20">Schedule a Call</a>
             </div>
         </div>
     </section>
@@ -232,6 +233,15 @@
       }
     </script>
 
+    <script src="../hero-nodes.js"></script>
+    <script>
+      initHeroNodes('investor-hero-canvas', {
+        nodeColor: '#8b5cf6',
+        lineColor: 'rgba(139,92,246,0.3)',
+        nodeCount: 60,
+        connectionDistance: 150
+      });
+    </script>
     <script>
       (function(d,t) {
         var BASE_URL="https://support.orbas.io";


### PR DESCRIPTION
## Summary
- Introduce high-resolution `initHeroNodes` with configurable node size and connection range for sharper hero animations
- Ensure full-width canvases and relative script loading so node backdrops render across home, agency, and investor pages
- Boost node density and distances on each hero for a more expansive visual effect

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b18c932748832097ef10c1b29079fa