### PR TITLE
Speed up red banner ticker

### DIFF
--- a/OrbusLanding/index.html
+++ b/OrbusLanding/index.html
@@ -53,7 +53,7 @@
             100% { transform: translateX(-50%); }
         }
         .ticker-animation {
-            animation: ticker 30s linear infinite;
+            animation: ticker 15s linear infinite;
             will-change: transform;
         }
     </style>


### PR DESCRIPTION
## Summary
- Increase red banner ticker speed by halving animation duration.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1a122cb508320a3ba08080a0d5f92