### PR TITLE
Extend home page banner countdowns by one week

### DIFF
--- a/OrbusLanding/index.html
+++ b/OrbusLanding/index.html
@@ -133,13 +133,13 @@
         <div class="absolute bottom-0 left-0 w-full bg-red-600 text-white overflow-hidden">
             <div class="ticker flex whitespace-nowrap ticker-animation">
                 <div class="px-8 flex items-center text-right font-bold text-lg">Orbas AI: Out Now!</div>
-                <div class="px-8 flex items-center text-right font-bold text-lg">Orbas Freelance: Upgrading All Systems <span class="countdown mx-2" data-end="2025-09-16T00:00:00Z"></span></div>
-                <div class="px-8 flex items-center text-right font-bold text-lg">Orbas Learn: Upgrading All Systems <span class="countdown mx-2" data-end="2025-09-18T00:00:00Z"></span></div>
-                <div class="px-8 flex items-center text-right font-bold text-lg">Orbas Services: Upgrading All Systems <span class="countdown mx-2" data-end="2025-09-17T00:00:00Z"></span></div>
+                <div class="px-8 flex items-center text-right font-bold text-lg">Orbas Freelance: Upgrading All Systems <span class="countdown mx-2" data-end="2025-09-23T00:00:00Z"></span></div>
+                <div class="px-8 flex items-center text-right font-bold text-lg">Orbas Learn: Upgrading All Systems <span class="countdown mx-2" data-end="2025-09-25T00:00:00Z"></span></div>
+                <div class="px-8 flex items-center text-right font-bold text-lg">Orbas Services: Upgrading All Systems <span class="countdown mx-2" data-end="2025-09-24T00:00:00Z"></span></div>
                 <div class="px-8 flex items-center text-right font-bold text-lg">Orbas AI: Out Now!</div>
-                <div class="px-8 flex items-center text-right font-bold text-lg">Orbas Freelance: Upgrading All Systems <span class="countdown mx-2" data-end="2025-09-16T00:00:00Z"></span></div>
-                <div class="px-8 flex items-center text-right font-bold text-lg">Orbas Learn: Upgrading All Systems <span class="countdown mx-2" data-end="2025-09-18T00:00:00Z"></span></div>
-                <div class="px-8 flex items-center text-right font-bold text-lg">Orbas Services: Upgrading All Systems <span class="countdown mx-2" data-end="2025-09-17T00:00:00Z"></span></div>
+                <div class="px-8 flex items-center text-right font-bold text-lg">Orbas Freelance: Upgrading All Systems <span class="countdown mx-2" data-end="2025-09-23T00:00:00Z"></span></div>
+                <div class="px-8 flex items-center text-right font-bold text-lg">Orbas Learn: Upgrading All Systems <span class="countdown mx-2" data-end="2025-09-25T00:00:00Z"></span></div>
+                <div class="px-8 flex items-center text-right font-bold text-lg">Orbas Services: Upgrading All Systems <span class="countdown mx-2" data-end="2025-09-24T00:00:00Z"></span></div>
             </div>
         </div>
     </section>


### PR DESCRIPTION
## Summary
- add seven days to countdown dates on the home page red banner so timers run longer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b86356f2c083208436d558c6f196b3