### PR TITLE
feat: restore hero network and showcase orb section

### DIFF
--- a/OrbusLanding/agency/index.html
+++ b/OrbusLanding/agency/index.html
@@ -179,7 +179,7 @@
     <section
       class="relative bg-gradient-to-br from-gray-900 via-orbas-dark-blue to-orbas-blue py-32 px-4 sm:px-6 lg:px-8 overflow-hidden"
     >
-      <canvas id="agency-hero-canvas" class="absolute inset-0 w-full h-full pointer-events-none"></canvas>
+      <canvas id="agency-hero-canvas" class="absolute inset-0 w-full h-full pointer-events-none" aria-hidden="true"></canvas>
       <div class="absolute inset-0 bg-black/20"></div>
       <div
         class="relative max-w-7xl mx-auto grid grid-cols-1 lg:grid-cols-2 gap-16 items-center"

--- a/OrbusLanding/data-orb.js
+++ b/OrbusLanding/data-orb.js
@@ -1,0 +1,230 @@
+function initDataOrb(id, opts = {}) {
+  const canvas = document.getElementById(id);
+  if (!canvas) return;
+
+  const ctx = canvas.getContext('2d');
+  const config = Object.assign({
+    nodeColor: '#60a5fa',
+    lineColor: '#3b82f6',
+    nodeCount: 140,
+    nodeSize: 3,
+    lineWidth: 1,
+    connectionDistance: 0.58,
+    rotationSpeedX: 0.00018,
+    rotationSpeedY: 0.00042,
+    rotationSpeedZ: 0.00012,
+    sphereScale: 0.8,
+    cameraDistance: 3.6,
+    depthScale: 1,
+    glowStrength: 18,
+    initialRotationX: -0.35,
+    initialRotationY: 0.7,
+    initialRotationZ: 0.15
+  }, opts);
+
+  const dpr = window.devicePixelRatio || 1;
+  const connectionLimit = Math.max(0.1, config.connectionDistance);
+  let width = 0;
+  let height = 0;
+  let radius = 0;
+  let rotationX = config.initialRotationX;
+  let rotationY = config.initialRotationY;
+  let rotationZ = config.initialRotationZ;
+  let lastTime = performance.now();
+
+  const baseNodeColor = parseColor(config.nodeColor);
+  const baseLineColor = parseColor(config.lineColor);
+  const nodes = createNodes(config.nodeCount);
+
+  function createNodes(count) {
+    const nodesArr = [];
+    const offset = 2 / count;
+    const increment = Math.PI * (3 - Math.sqrt(5));
+    for (let i = 0; i < count; i++) {
+      const y = i * offset - 1 + offset / 2;
+      const r = Math.sqrt(Math.max(0, 1 - y * y));
+      const phi = i * increment;
+      const x = Math.cos(phi) * r;
+      const z = Math.sin(phi) * r;
+      nodesArr.push({
+        x,
+        y,
+        z,
+        wobbleOffset: Math.random() * Math.PI * 2,
+        wobbleSpeed: 0.5 + Math.random() * 0.9,
+        wobbleMagnitude: 0.015 + Math.random() * 0.025
+      });
+    }
+    return nodesArr;
+  }
+
+  function parseColor(value) {
+    if (!value) return { r: 255, g: 255, b: 255, a: 1 };
+    if (value.startsWith('#')) {
+      let hex = value.slice(1);
+      if (hex.length === 3) {
+        hex = hex.split('').map((c) => c + c).join('');
+      }
+      const num = parseInt(hex, 16);
+      return {
+        r: (num >> 16) & 255,
+        g: (num >> 8) & 255,
+        b: num & 255,
+        a: 1
+      };
+    }
+    const match = value.match(/rgba?\(([^)]+)\)/i);
+    if (match) {
+      const parts = match[1].split(',').map((part) => part.trim());
+      const r = parseFloat(parts[0]);
+      const g = parseFloat(parts[1]);
+      const b = parseFloat(parts[2]);
+      const a = parts[3] !== undefined ? parseFloat(parts[3]) : 1;
+      return { r, g, b, a: isNaN(a) ? 1 : a };
+    }
+    return { r: 255, g: 255, b: 255, a: 1 };
+  }
+
+  function colorWithAlpha(color, alpha) {
+    const safeAlpha = Math.min(1, Math.max(0, alpha));
+    return `rgba(${color.r}, ${color.g}, ${color.b}, ${safeAlpha * (color.a !== undefined ? color.a : 1)})`;
+  }
+
+  function resize() {
+    const rect = canvas.getBoundingClientRect();
+    if (!rect.width || !rect.height) {
+      return;
+    }
+    width = rect.width;
+    height = rect.height;
+    radius = Math.min(width, height) / 2 * config.sphereScale;
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  }
+
+  resize();
+  window.addEventListener('resize', resize);
+  window.addEventListener('orientationchange', () => setTimeout(resize, 200));
+  if (typeof ResizeObserver !== 'undefined') {
+    const observer = new ResizeObserver(resize);
+    observer.observe(canvas);
+  }
+  setTimeout(resize, 120);
+
+  function transformNode(node, timeSeconds) {
+    const wobble = Math.sin(timeSeconds * node.wobbleSpeed + node.wobbleOffset) * node.wobbleMagnitude;
+    const scale = 1 + wobble;
+
+    let x = node.x * scale;
+    let y = node.y * scale;
+    let z = node.z * scale;
+
+    const cosY = Math.cos(rotationY);
+    const sinY = Math.sin(rotationY);
+    let dx = x * cosY - z * sinY;
+    let dz = x * sinY + z * cosY;
+
+    const cosX = Math.cos(rotationX);
+    const sinX = Math.sin(rotationX);
+    let dy = y * cosX - dz * sinX;
+    dz = y * sinX + dz * cosX;
+
+    const cosZ = Math.cos(rotationZ);
+    const sinZ = Math.sin(rotationZ);
+    const rx = dx * cosZ - dy * sinZ;
+    const ry = dx * sinZ + dy * cosZ;
+    const rz = dz;
+
+    const depth = config.cameraDistance / (config.cameraDistance - rz * config.depthScale);
+    const screenX = rx * radius * depth + width / 2;
+    const screenY = ry * radius * depth + height / 2;
+
+    return {
+      screenX,
+      screenY,
+      rotatedX: rx,
+      rotatedY: ry,
+      rotatedZ: rz,
+      depth
+    };
+  }
+
+  function render(time) {
+    let delta = time - lastTime;
+    if (!isFinite(delta) || delta <= 0) {
+      delta = 16;
+    } else {
+      delta = Math.min(32, delta);
+    }
+    lastTime = time;
+    rotationX += config.rotationSpeedX * delta;
+    rotationY += config.rotationSpeedY * delta;
+    rotationZ += config.rotationSpeedZ * delta;
+
+    if (!width || !height) {
+      requestAnimationFrame(render);
+      return;
+    }
+
+    ctx.clearRect(0, 0, width, height);
+
+    const timeSeconds = time * 0.001;
+    const transformed = nodes.map((node) => transformNode(node, timeSeconds));
+
+    for (let i = 0; i < transformed.length; i++) {
+      for (let j = i + 1; j < transformed.length; j++) {
+        const a = transformed[i];
+        const b = transformed[j];
+        const dx = a.rotatedX - b.rotatedX;
+        const dy = a.rotatedY - b.rotatedY;
+        const dz = a.rotatedZ - b.rotatedZ;
+        const distance = Math.sqrt(dx * dx + dy * dy + dz * dz);
+        if (distance < connectionLimit) {
+          const intensity = 1 - distance / connectionLimit;
+          const depthBoost = (a.depth + b.depth) * 0.5 - 1;
+          const alpha = Math.min(1, 0.1 + intensity * 0.85 + depthBoost * 0.25);
+          ctx.strokeStyle = colorWithAlpha(baseLineColor, alpha);
+          ctx.lineWidth = config.lineWidth * (0.7 + intensity * 0.6);
+          ctx.beginPath();
+          ctx.moveTo(a.screenX, a.screenY);
+          ctx.lineTo(b.screenX, b.screenY);
+          ctx.stroke();
+        }
+      }
+    }
+
+    const sorted = transformed.slice().sort((a, b) => a.rotatedZ - b.rotatedZ);
+    for (const node of sorted) {
+      const depthNormal = (node.rotatedZ + 1) / 2;
+      const radiusScale = Math.max(0.5, Math.min(1.5, node.depth));
+      const nodeRadius = config.nodeSize * radiusScale;
+      const glow = Math.max(0, (node.depth - 1) * config.glowStrength);
+      const alpha = 0.35 + depthNormal * 0.55;
+
+      ctx.save();
+      ctx.shadowBlur = glow;
+      ctx.shadowColor = colorWithAlpha(baseNodeColor, 0.6);
+      ctx.fillStyle = colorWithAlpha(baseNodeColor, alpha);
+      ctx.beginPath();
+      ctx.arc(node.screenX, node.screenY, nodeRadius, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.restore();
+
+      ctx.beginPath();
+      ctx.strokeStyle = colorWithAlpha(baseNodeColor, Math.min(0.45, alpha));
+      ctx.lineWidth = 0.6;
+      ctx.arc(node.screenX, node.screenY, nodeRadius, 0, Math.PI * 2);
+      ctx.stroke();
+
+      ctx.beginPath();
+      ctx.fillStyle = colorWithAlpha(baseNodeColor, Math.min(1, alpha + 0.2));
+      ctx.arc(node.screenX, node.screenY, nodeRadius * 0.45, 0, Math.PI * 2);
+      ctx.fill();
+    }
+
+    requestAnimationFrame(render);
+  }
+
+  requestAnimationFrame(render);
+}

--- a/OrbusLanding/index.html
+++ b/OrbusLanding/index.html
@@ -56,7 +56,7 @@
         <canvas id="home-hero-canvas" class="absolute inset-0 w-full h-full pointer-events-none"></canvas>
         <!-- Background overlay -->
         <div class="absolute inset-0 bg-black/20"></div>
-        
+
         <div class="relative max-w-7xl mx-auto">
             <div class="grid grid-cols-1 lg:grid-cols-2 gap-16 items-center">
                 <!-- Left content -->
@@ -66,7 +66,7 @@
                         <span class="mr-2">⚡</span>
                         Unleash Innovation with Intelligent Automation
                     </div>
-                    
+
                     <h1 class="text-4xl sm:text-5xl lg:text-5xl font-bold text-white mb-6 leading-tight">
                         The Complete
                         <span class="bg-gradient-to-r from-blue-400 via-purple-400 to-pink-400 bg-clip-text text-transparent">
@@ -74,11 +74,11 @@
                         </span>
                         for Digital Transformation
                     </h1>
-                    
+
                     <p class="text-lg sm:text-xl text-gray-300 mb-10 leading-relaxed">
                         Four integrated platforms unify AI automation, vetted professionals, curated learning and always-on services—with agency expertise available whenever you need it.
                     </p>
-                    
+
                     <div class="flex flex-col sm:flex-row gap-6">
                         <a href="#platforms" class="inline-flex items-center justify-center px-8 py-4 bg-gradient-to-r from-blue-600/80 to-purple-600/80 hover:from-blue-700/80 hover:to-purple-700/80 text-white font-semibold rounded-xl transition-all duration-200 shadow-lg hover:shadow-xl transform hover:-translate-y-1 backdrop-blur-md border border-white/20">
                             Explore Platforms
@@ -100,7 +100,7 @@
                         </a>
                     </div>
                 </div>
-                
+
                 <!-- Right image -->
                 <div class="relative">
                     <div class="relative overflow-hidden rounded-2xl shadow-2xl">
@@ -113,7 +113,7 @@
                             </div>
                         </div>
                     </div>
-                    
+
                     <!-- Floating elements -->
                     <div class="absolute -top-4 -right-4 w-20 h-20 bg-gradient-to-br from-purple-400 to-pink-500 rounded-full opacity-60 animate-bounce"></div>
                     <div class="absolute -bottom-4 -left-4 w-16 h-16 bg-gradient-to-br from-blue-400 to-cyan-500 rounded-full opacity-40 animate-bounce"></div>
@@ -167,7 +167,55 @@
             </div>
         </div>
     </section>
-                
+
+    <!-- Intelligent Automation Visual -->
+    <section class="relative py-24 px-4 sm:px-6 lg:px-8 bg-gradient-to-br from-slate-900 via-blue-900 to-indigo-900 text-white overflow-hidden">
+        <div class="absolute inset-0 opacity-40 bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.3),_transparent_55%)]"></div>
+        <div class="relative max-w-7xl mx-auto grid grid-cols-1 lg:grid-cols-2 gap-16 items-center">
+            <div>
+                <p class="inline-flex items-center px-4 py-2 rounded-full text-sm font-medium bg-white/10 border border-white/20 mb-6">
+                    <span class="mr-2">🪐</span>
+                    Live Network Visual
+                </p>
+                <h2 class="text-3xl sm:text-4xl font-bold mb-6">See the Orbas Data Mesh in Motion</h2>
+                <p class="text-lg text-blue-100/90 leading-relaxed mb-6">
+                    This dynamic orb mirrors the real-time activity inside our ecosystem. Each node represents an automation, specialist or learning stream connecting across platforms to deliver seamless outcomes day and night.
+                </p>
+                <ul class="space-y-3 text-blue-100/80">
+                    <li class="flex items-start">
+                        <span class="mr-3 mt-1 text-blue-300">•</span>
+                        Responsive rendering keeps the visual crisp on phones, tablets and desktops.
+                    </li>
+                    <li class="flex items-start">
+                        <span class="mr-3 mt-1 text-blue-300">•</span>
+                        Wobbling nodes and glowing trails highlight high-impact automations.
+                    </li>
+                    <li class="flex items-start">
+                        <span class="mr-3 mt-1 text-blue-300">•</span>
+                        Lightweight canvas animation loads instantly without blocking content.
+                    </li>
+                </ul>
+            </div>
+            <div class="relative flex justify-center lg:justify-end">
+                <div class="relative w-full max-w-[420px] aspect-square mx-auto">
+                    <div class="absolute inset-0 rounded-full bg-gradient-to-br from-blue-500/40 via-transparent to-purple-500/40 blur-3xl"></div>
+                    <div class="absolute inset-4 rounded-full border border-white/10 backdrop-blur-sm"></div>
+                    <canvas id="innovation-orb-canvas" class="relative z-10 block w-full h-full" aria-hidden="true"></canvas>
+                    <div class="absolute inset-0 z-20 pointer-events-none">
+                        <div class="absolute -top-6 right-6 w-14 h-14 bg-gradient-to-br from-blue-400/70 to-cyan-400/70 rounded-full blur-sm animate-pulse"></div>
+                        <div class="absolute -bottom-8 left-10 w-16 h-16 bg-gradient-to-br from-purple-500/60 to-pink-500/70 rounded-full blur"></div>
+                    </div>
+                    <div class="absolute bottom-6 left-1/2 z-20 w-60 -translate-x-1/2">
+                        <div class="bg-white/10 border border-white/10 backdrop-blur-lg rounded-2xl px-6 py-4 shadow-xl text-center">
+                            <p class="text-sm font-semibold uppercase tracking-wide text-blue-100">Adaptive Data Sphere</p>
+                            <p class="text-xs text-blue-100/80 mt-1">Visualising secure cross-platform orchestration</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
     <!-- Platforms Section -->
     <section id="platforms" class="py-24 px-4 sm:px-6 lg:px-8 bg-gray-50">
         <div class="max-w-7xl mx-auto">
@@ -458,6 +506,20 @@
         lineColor: 'rgba(96,165,250,0.3)',
         nodeCount: 80,
         connectionDistance: 160
+      });
+    </script>
+    <script src="data-orb.js"></script>
+    <script>
+      initDataOrb('innovation-orb-canvas', {
+        nodeColor: '#7dd3fc',
+        lineColor: '#60a5fa',
+        nodeCount: 160,
+        nodeSize: 3,
+        lineWidth: 1,
+        connectionDistance: 0.6,
+        rotationSpeedX: 0.00014,
+        rotationSpeedY: 0.00034,
+        rotationSpeedZ: 0.0001
       });
     </script>
     <script src="/layout.js"></script>

--- a/OrbusLanding/investors/index.html
+++ b/OrbusLanding/investors/index.html
@@ -76,7 +76,7 @@
     </div>
 
     <section class="relative isolate overflow-hidden bg-gradient-to-br from-blue-950 via-indigo-900 to-purple-900 py-32 px-4 sm:px-6 lg:px-8">
-        <canvas id="investor-hero-canvas" class="absolute inset-0 w-full h-full pointer-events-none"></canvas>
+        <canvas id="investor-hero-canvas" class="absolute inset-0 w-full h-full pointer-events-none" aria-hidden="true"></canvas>
         <div class="absolute inset-0 pointer-events-none">
             <div class="absolute -top-24 -left-24 w-96 h-96 bg-orbas-blue/40 blur-3xl rounded-full"></div>
             <div class="absolute bottom-0 right-0 w-80 h-80 bg-orbas-purple/40 blur-2xl rounded-full"></div>


### PR DESCRIPTION
## Summary
- revert the homepage hero to its original background network, restoring the simple hero-nodes renderer
- introduce a dedicated "Live Network Visual" section mid-page that uses the new data orb animation and supporting copy
- update agency and investor pages to continue using the classic hero node configuration shared by the restored renderer

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d033b44a248320abed9df955b862a1