### PR TITLE
Reframe opportunity orb copy as matrix

### DIFF
--- a/OrbusLanding/index.html
+++ b/OrbusLanding/index.html
@@ -175,24 +175,24 @@
             <div>
                 <p class="inline-flex items-center px-4 py-2 rounded-full text-sm font-medium bg-white/10 border border-white/20 mb-6">
                     <span class="mr-2">🪐</span>
-                    Global Opportunity Monitor
+                    Global Opportunity Matrix
                 </p>
-                <h2 class="text-3xl sm:text-4xl font-bold mb-6">Experience the Orbas Opportunity Graph</h2>
+                <h2 class="text-3xl sm:text-4xl font-bold mb-6">See Who's Ready to Connect with Orbas</h2>
                 <p class="text-lg text-blue-100/90 leading-relaxed mb-6">
-                    The live orb is a real-time expression of the enterprise community forming on Orbas. Every luminous node represents a specialist, project room or learning stream ready to engage, while the connective arcs reveal how work, skills and services flow between continents.
+                    The live orb renders a boardroom-ready matrix of enterprises, specialists, educators and AI services orbiting the Orbas ecosystem. This is not a depiction of those already signed up; it is a living representation of potential opportunities across the network ready to connect with you. Each luminous coordinate highlights a partner prepared to co-build, teach or deliver—even before they formally join—so you can activate the right expertise the moment your project needs it.
                 </p>
                 <ul class="space-y-3 text-blue-100/80">
                     <li class="flex items-start">
                         <span class="mr-3 mt-1 text-blue-300">•</span>
-                        Adaptive rendering delivers boardroom clarity and mobile responsiveness without sacrificing fidelity.
+                        Intelligent filters surface revenue, learning and service opportunities across every market in real time.
                     </li>
                     <li class="flex items-start">
                         <span class="mr-3 mt-1 text-blue-300">•</span>
-                        Motion signals surface active engagements, open briefs and cross-border learning pathways in the moment they appear.
+                        Dynamic signals reveal open briefs, specialist availability and AI-enabled capacity ready to mobilise your next initiative.
                     </li>
                     <li class="flex items-start">
                         <span class="mr-3 mt-1 text-blue-300">•</span>
-                        Optimised canvas performance keeps executives and teams in flow while evaluating partnership potential.
+                        Enterprise-grade clarity keeps decision makers aligned—from strategic partnerships to on-demand task forces.
                     </li>
                 </ul>
             </div>
@@ -207,8 +207,8 @@
                     </div>
                     <div class="absolute bottom-6 left-1/2 z-20 w-60 -translate-x-1/2">
                         <div class="bg-white/10 border border-white/10 backdrop-blur-lg rounded-2xl px-6 py-4 shadow-xl text-center">
-                            <p class="text-sm font-semibold uppercase tracking-wide text-blue-100">Global Collaboration Console</p>
-                            <p class="text-xs text-blue-100/80 mt-1">A visual index of the worldwide opportunities forming inside Orbas</p>
+                            <p class="text-sm font-semibold uppercase tracking-wide text-blue-100">Opportunity Matrix Console</p>
+                            <p class="text-xs text-blue-100/80 mt-1">A living map of global collaborators ready to activate with you</p>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- Reframed the orb section copy as a global opportunity matrix highlighting prospects ready to connect with Orbas.
- Updated supporting bullet points to emphasize revenue, learning, and AI-enabled collaboration signals.
- Renamed the console caption to align with the opportunity matrix narrative.
- Clarified that the visualization reflects potential opportunities not yet signed up with Orbas.

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68d03f45a148832083a71a0f68858ef6