### PR TITLE
Update public pages for Alpha 1 communications

### DIFF
--- a/OrbusLanding/careers/index.html
+++ b/OrbusLanding/careers/index.html
@@ -51,8 +51,8 @@
     <main class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16 space-y-16">
         <section class="bg-white border border-gray-200 rounded-2xl shadow-lg p-10 text-center">
             <h2 class="text-3xl font-bold text-gray-900 mb-4">Current Opportunities</h2>
-            <p class="text-gray-700 text-lg leading-relaxed">There are no open positions at this time. New opportunities across product, engineering, design, operations and go-to-market will be published here as they become available.</p>
-            <p class="text-gray-700 text-lg leading-relaxed mt-4">If you would like to be notified about future roles, join our talent network below.</p>
+            <p class="text-gray-700 text-lg leading-relaxed">We do not have any open positions right now. The core team is focused on delivering our Alpha 1 programmes and assessing long-term hiring needs.</p>
+            <p class="text-gray-700 text-lg leading-relaxed mt-4">We review headcount plans quarterly and will post roles across product, engineering, design, operations and go-to-market as soon as they are confirmed. Please check back here for updates.</p>
         </section>
 
         <section class="grid grid-cols-1 lg:grid-cols-3 gap-8">
@@ -105,7 +105,7 @@
                 </div>
                 <div class="bg-gray-50 border border-gray-200 rounded-xl p-8">
                     <h3 class="text-2xl font-semibold text-gray-900 mb-4">Join the Talent Network</h3>
-                    <p class="text-gray-700 leading-relaxed mb-6">Email <a href="mailto:careers@orbas.io" class="text-orbas-dark-blue underline">careers@orbas.io</a> with your CV, portfolio links and areas of interest.</p>
+                    <p class="text-gray-700 leading-relaxed mb-6">Email <a href="mailto:support@orbas.io?subject=Talent%20Network" class="text-orbas-dark-blue underline">support@orbas.io</a> with your CV, portfolio links and areas of interest so we can log your profile for future reviews.</p>
                     <p class="text-gray-700 leading-relaxed">We also encourage you to follow our updates in the <a href="/impact" class="text-orbas-dark-blue underline">Impact</a> hub and <a href="/release-notes" class="text-orbas-dark-blue underline">Release Notes</a>.</p>
                 </div>
             </div>
@@ -113,7 +113,7 @@
 
         <section class="bg-blue-50 border border-blue-100 rounded-2xl p-10 shadow-sm text-center">
             <h2 class="text-3xl font-bold text-blue-900 mb-4">Contractor &amp; Partner Opportunities</h2>
-            <p class="text-blue-900 leading-relaxed mb-4">We collaborate with freelancers, agencies and specialists across the globe. If you are interested in contract work, visit <a href="https://freelance.orbas.io" class="text-orbas-dark-blue underline">Orbas Freelance</a> or contact <a href="mailto:partners@orbas.io" class="text-orbas-dark-blue underline">partners@orbas.io</a>.</p>
+            <p class="text-blue-900 leading-relaxed mb-4">We collaborate with freelancers, agencies and specialists across the globe. If you are interested in contract work, visit <a href="https://freelance.orbas.io" class="text-orbas-dark-blue underline">Orbas Freelance</a> or email <a href="mailto:support@orbas.io?subject=Partner%20Enquiry" class="text-orbas-dark-blue underline">support@orbas.io</a>.</p>
             <p class="text-blue-900 leading-relaxed">Our supplier standards are detailed in the <a href="/modern-slavery" class="text-orbas-dark-blue underline">Modern Slavery Statement</a> and <a href="/esg-csr" class="text-orbas-dark-blue underline">ESG commitment</a>.</p>
         </section>
     </main>

--- a/OrbusLanding/company-culture/index.html
+++ b/OrbusLanding/company-culture/index.html
@@ -56,11 +56,11 @@
             </div>
             <div class="bg-white border border-gray-200 rounded-2xl shadow-lg p-8">
                 <h2 class="text-2xl font-semibold text-gray-900 mb-4">Our Promise</h2>
-                <p class="text-gray-700 leading-relaxed">We deliver dependable outcomes with the pace of a start-up and the governance of an enterprise. That balance keeps our teams grounded, creative and trusted by global clients.</p>
+                <p class="text-gray-700 leading-relaxed">As an early-stage business we balance ambition with pragmatism. We commit to clear communication, realistic delivery plans and governance that scales with our customer base.</p>
             </div>
             <div class="bg-white border border-gray-200 rounded-2xl shadow-lg p-8">
                 <h2 class="text-2xl font-semibold text-gray-900 mb-4">Our People</h2>
-                <p class="text-gray-700 leading-relaxed">We bring together engineers, strategists, educators and operators united by a growth mindset. We celebrate the diversity of our distributed workforce and equip each person to lead from where they are.</p>
+                <p class="text-gray-700 leading-relaxed">We bring together engineers, strategists, educators and operators united by a growth mindset. Our distributed team is small but multi-disciplinary, and we invest in the tools and rituals that help everyone contribute with confidence.</p>
             </div>
         </section>
 
@@ -69,7 +69,7 @@
             <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
                 <div>
                     <h3 class="text-xl font-semibold text-blue-900 mb-3">Customer Trust is Earned</h3>
-                    <p class="text-blue-900 leading-relaxed">We embed quality, security and transparent communication into every client touchpoint. Teams share responsibility for safeguarding the reputation of Blackridge Group Ltd and each Orbas platform.</p>
+                    <p class="text-blue-900 leading-relaxed">We embed quality, security and transparent communication into every client touchpoint. Each squad shares responsibility for safeguarding the reputation of Blackridge Group Ltd and each Orbas platform.</p>
                 </div>
                 <div>
                     <h3 class="text-xl font-semibold text-blue-900 mb-3">Innovation with Integrity</h3>
@@ -92,14 +92,14 @@
                     <h2 class="text-3xl font-bold text-gray-900 mb-6">How We Work</h2>
                     <ul class="space-y-5 text-gray-700 leading-relaxed">
                         <li><strong>Hybrid by Design:</strong> We blend remote-first flexibility with purposeful in-person gatherings to strengthen relationships and accelerate breakthroughs.</li>
-                        <li><strong>Empowered Teams:</strong> Squads run rapid delivery cycles, supported by domain experts in security, legal and compliance to ensure enterprise readiness.</li>
+                        <li><strong>Empowered Teams:</strong> Lean squads own end-to-end outcomes and tap into fractional specialists for security, legal and compliance guidance as needed.</li>
                         <li><strong>Transparent Roadmaps:</strong> Quarterly business reviews and open town halls keep everyone informed about priorities, metrics and upcoming releases.</li>
                         <li><strong>Continuous Learning:</strong> Every employee has access to Orbas Learn courses, mentoring programmes and dedicated innovation time.</li>
                     </ul>
                 </div>
                 <div class="bg-gray-50 border border-gray-200 rounded-xl p-8">
                     <h3 class="text-2xl font-semibold text-gray-900 mb-4">Wellbeing &amp; Inclusion</h3>
-                    <p class="text-gray-700 leading-relaxed mb-4">Our people policies are anchored in care. We recognise different life stages and offer flexible arrangements, mental health support and inclusive benefits across all locations.</p>
+                    <p class="text-gray-700 leading-relaxed mb-4">Our people policies are anchored in care. We recognise different life stages and offer flexible arrangements, mental health support signposting and a growing benefits stack that we review every six months.</p>
                     <p class="text-gray-700 leading-relaxed">We also track the commitments outlined in our <a href="/equality-diversity" class="text-orbas-dark-blue underline">Equality &amp; Diversity</a> statement and report progress in our <a href="/impact" class="text-orbas-dark-blue underline">Impact</a> centre.</p>
                 </div>
             </div>
@@ -127,7 +127,7 @@
             <h2 class="text-3xl font-bold text-gray-900 mb-6">Shape the Future with Us</h2>
             <p class="text-gray-700 text-lg leading-relaxed mb-6">Our culture is continually evolving as we grow. We invite you to stay connected through our <a href="/careers" class="text-orbas-dark-blue underline">Careers</a> hub, <a href="/release-notes" class="text-orbas-dark-blue underline">Release Notes</a> and investor updates. Together we are building a resilient, ethical and high-performing ecosystem.</p>
             <div class="flex flex-col sm:flex-row gap-4">
-                <a href="mailto:people@orbas.io" class="inline-flex items-center justify-center px-6 py-3 bg-orbas-dark-blue text-white font-semibold rounded-lg shadow hover:bg-blue-800 transition-colors">Connect with our People Team</a>
+                <a href="mailto:support@orbas.io?subject=People%20Team" class="inline-flex items-center justify-center px-6 py-3 bg-orbas-dark-blue text-white font-semibold rounded-lg shadow hover:bg-blue-800 transition-colors">Connect with our People Team</a>
                 <a href="/impact" class="inline-flex items-center justify-center px-6 py-3 bg-white border border-gray-300 text-gray-900 font-semibold rounded-lg shadow hover:border-orbas-dark-blue hover:text-orbas-dark-blue transition-colors">Discover Our Impact</a>
             </div>
         </section>

--- a/OrbusLanding/impact/index.html
+++ b/OrbusLanding/impact/index.html
@@ -51,7 +51,7 @@
     <main class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16 space-y-16">
         <section class="bg-white border border-gray-200 rounded-2xl shadow-lg p-10">
             <h2 class="text-3xl font-bold text-gray-900 mb-6">Our Focus Areas</h2>
-            <p class="text-gray-700 text-lg leading-relaxed mb-6">Impact is measured across the four pillars that matter most to our stakeholders and align with our <a href="/esg-csr" class="text-orbas-dark-blue underline">ESG &amp; CSR commitment</a>.</p>
+            <p class="text-gray-700 text-lg leading-relaxed mb-6">Impact is measured across the four pillars that matter most to our stakeholders and align with our <a href="/esg-csr" class="text-orbas-dark-blue underline">ESG &amp; CSR commitment</a>. We are capturing baseline data during the first six months following the Alpha 1 launch and will publish verified metrics once the review is complete.</p>
             <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
                 <div class="border border-blue-100 bg-blue-50 rounded-2xl p-8 shadow-sm">
                     <h3 class="text-2xl font-semibold text-blue-900 mb-3">Responsible Technology</h3>
@@ -74,21 +74,22 @@
 
         <section class="bg-gray-50 border border-gray-200 rounded-2xl p-10 shadow-sm">
             <h2 class="text-3xl font-bold text-gray-900 mb-6">Impact Dashboard</h2>
+            <p class="text-gray-700 leading-relaxed mb-6">We are building a transparent dashboard that will be refreshed every six months. The first data set, covering September 2025 to February 2026, is currently in collection. Interim focus areas are outlined below.</p>
             <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
                 <div class="bg-white border border-gray-200 rounded-xl p-6 shadow">
-                    <p class="text-sm uppercase tracking-widest text-gray-500">Empowered Projects</p>
-                    <p class="text-4xl font-bold text-gray-900 mt-2">+120</p>
-                    <p class="text-gray-600 mt-3">Enterprise transformation initiatives supported through Orbas Services and Orbas AI since 2023.</p>
+                    <p class="text-sm uppercase tracking-widest text-gray-500">Baseline Assessment</p>
+                    <p class="text-2xl font-bold text-gray-900 mt-2">In Progress</p>
+                    <p class="text-gray-600 mt-3">Measuring outcomes from four founding customer pilots to understand efficiency gains and user satisfaction.</p>
                 </div>
                 <div class="bg-white border border-gray-200 rounded-xl p-6 shadow">
-                    <p class="text-sm uppercase tracking-widest text-gray-500">Global Talent Network</p>
-                    <p class="text-4xl font-bold text-gray-900 mt-2">65+</p>
-                    <p class="text-gray-600 mt-3">Countries represented by specialists and educators collaborating through Orbas Freelance and Orbas Learn.</p>
+                    <p class="text-sm uppercase tracking-widest text-gray-500">Talent Network</p>
+                    <p class="text-2xl font-bold text-gray-900 mt-2">Pilot Cohort</p>
+                    <p class="text-gray-600 mt-3">Tracking the onboarding experience of the initial freelance specialists and educators supporting Alpha delivery.</p>
                 </div>
                 <div class="bg-white border border-gray-200 rounded-xl p-6 shadow">
-                    <p class="text-sm uppercase tracking-widest text-gray-500">Learning Impact</p>
-                    <p class="text-4xl font-bold text-gray-900 mt-2">45K</p>
-                    <p class="text-gray-600 mt-3">Course enrolments delivering future-ready skills for customers, partners and communities.</p>
+                    <p class="text-sm uppercase tracking-widest text-gray-500">Next Update</p>
+                    <p class="text-2xl font-bold text-gray-900 mt-2">March 2026</p>
+                    <p class="text-gray-600 mt-3">Publicly share quantitative metrics and lessons learned once the first six-month review is completed.</p>
                 </div>
             </div>
         </section>
@@ -97,36 +98,36 @@
             <h2 class="text-3xl font-bold text-gray-900 mb-6">Strategic Initiatives</h2>
             <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
                 <div class="border border-blue-100 bg-blue-50 rounded-2xl p-8 shadow-sm">
-                    <h3 class="text-2xl font-semibold text-blue-900 mb-3">Sustainable Cloud Programme</h3>
-                    <p class="text-blue-900 leading-relaxed">Aligns hosting partners with renewable energy, energy efficiency and responsible e-waste practices.</p>
-                    <a href="/esg-csr" class="inline-flex items-center mt-4 text-orbas-dark-blue font-semibold">Explore ESG &amp; CSR
+                    <h3 class="text-2xl font-semibold text-blue-900 mb-3">Pilot Outcome Tracking</h3>
+                    <p class="text-blue-900 leading-relaxed">Capturing automation hours saved, adoption sentiment and service quality from our first wave of customer projects.</p>
+                    <a href="/release-notes" class="inline-flex items-center mt-4 text-orbas-dark-blue font-semibold">See Product Updates
                         <svg class="ml-2 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
                         </svg>
                     </a>
                 </div>
                 <div class="border border-green-100 bg-green-50 rounded-2xl p-8 shadow-sm">
-                    <h3 class="text-2xl font-semibold text-green-900 mb-3">Inclusive Talent Acceleration</h3>
-                    <p class="text-green-900 leading-relaxed">Provides scholarships, mentorship and community projects to underrepresented technologists.</p>
-                    <a href="/careers" class="inline-flex items-center mt-4 text-orbas-dark-blue font-semibold">Visit Careers
+                    <h3 class="text-2xl font-semibold text-green-900 mb-3">Community Learning Partners</h3>
+                    <p class="text-green-900 leading-relaxed">Running quarterly skills workshops with co-working spaces and local colleges to broaden access to practical automation education.</p>
+                    <a href="/company-culture" class="inline-flex items-center mt-4 text-orbas-dark-blue font-semibold">Explore Culture
                         <svg class="ml-2 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
                         </svg>
                     </a>
                 </div>
                 <div class="border border-purple-100 bg-purple-50 rounded-2xl p-8 shadow-sm">
-                    <h3 class="text-2xl font-semibold text-purple-900 mb-3">Ethical Supply Chain Assurance</h3>
-                    <p class="text-purple-900 leading-relaxed">Ensures partners comply with the standards set out in our <a href="/modern-slavery" class="text-orbas-dark-blue underline">Modern Slavery Statement</a> and equality commitments.</p>
-                    <a href="/modern-slavery" class="inline-flex items-center mt-4 text-orbas-dark-blue font-semibold">Read Statement
+                    <h3 class="text-2xl font-semibold text-purple-900 mb-3">Responsible Operations</h3>
+                    <p class="text-purple-900 leading-relaxed">Formalising data governance, supplier onboarding and incident response playbooks suited to an early-stage enterprise.</p>
+                    <a href="/trust-safety-security" class="inline-flex items-center mt-4 text-orbas-dark-blue font-semibold">View Trust Standards
                         <svg class="ml-2 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
                         </svg>
                     </a>
                 </div>
                 <div class="border border-orange-100 bg-orange-50 rounded-2xl p-8 shadow-sm">
-                    <h3 class="text-2xl font-semibold text-orange-800 mb-3">Trusted Experience Platform</h3>
-                    <p class="text-orange-800 leading-relaxed">Invests in security, compliance and user protection across all Orbas touchpoints.</p>
-                    <a href="/trust-safety-security" class="inline-flex items-center mt-4 text-orbas-dark-blue font-semibold">View Trust Statement
+                    <h3 class="text-2xl font-semibold text-orange-800 mb-3">Supplier Standards Starter Pack</h3>
+                    <p class="text-orange-800 leading-relaxed">Providing new delivery partners with a concise onboarding checklist covering modern slavery compliance, wellbeing commitments and data security.</p>
+                    <a href="/modern-slavery" class="inline-flex items-center mt-4 text-orbas-dark-blue font-semibold">Review Policies
                         <svg class="ml-2 w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
                         </svg>
@@ -138,9 +139,9 @@
         <section class="bg-gray-50 border border-gray-200 rounded-2xl p-10 shadow-sm">
             <h2 class="text-3xl font-bold text-gray-900 mb-6">Partnerships &amp; Community Engagement</h2>
             <ul class="space-y-4 text-gray-700 leading-relaxed">
-                <li><strong>Industry Collaboration:</strong> Working with technology alliances to promote responsible AI and sustainability standards.</li>
-                <li><strong>Education Access:</strong> Offering subsidised Orbas Learn licences for charities, schools and workforce programmes.</li>
-                <li><strong>Local Impact:</strong> Volunteering and pro-bono support delivered by Orbas teams in partnership with community organisations.</li>
+                <li><strong>Industry Collaboration:</strong> Participating in regional responsible-AI working groups to align on practical safeguards for small teams.</li>
+                <li><strong>Education Access:</strong> Co-designing learning pilots with two community education partners and documenting outcomes for broader release.</li>
+                <li><strong>Local Impact:</strong> Planning bi-annual volunteering days with charities near our UK hubs once teams complete onboarding.</li>
             </ul>
         </section>
 
@@ -148,7 +149,7 @@
             <h2 class="text-3xl font-bold text-gray-900 mb-4">Stay Informed</h2>
             <p class="text-gray-700 text-lg leading-relaxed mb-4">We publish quarterly updates covering ESG progress, talent news and platform enhancements.</p>
             <div class="flex flex-col sm:flex-row justify-center gap-4">
-                <a href="mailto:impact@orbas.io" class="inline-flex items-center justify-center px-6 py-3 bg-orbas-dark-blue text-white font-semibold rounded-lg shadow hover:bg-blue-800 transition-colors">Contact the Impact Office</a>
+                <a href="mailto:support@orbas.io?subject=Impact%20Enquiry" class="inline-flex items-center justify-center px-6 py-3 bg-orbas-dark-blue text-white font-semibold rounded-lg shadow hover:bg-blue-800 transition-colors">Contact the Impact Office</a>
                 <a href="/release-notes" class="inline-flex items-center justify-center px-6 py-3 bg-white border border-gray-300 text-gray-900 font-semibold rounded-lg shadow hover:border-orbas-dark-blue hover:text-orbas-dark-blue transition-colors">View Release Notes</a>
             </div>
         </section>

--- a/OrbusLanding/release-notes/index.html
+++ b/OrbusLanding/release-notes/index.html
@@ -50,38 +50,39 @@
 
     <main class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16 space-y-16">
         <section class="bg-white border border-gray-200 rounded-2xl shadow-lg p-10">
-            <h2 class="text-3xl font-bold text-gray-900 mb-6">Latest Highlights</h2>
+            <h2 class="text-3xl font-bold text-gray-900 mb-6">September 2025 Alpha Releases</h2>
+            <p class="text-gray-700 leading-relaxed mb-6">All updates below shipped on <strong>13 September 2025</strong> as part of our coordinated Alpha 1 launch. Each product is now in controlled real-world testing with founding customers while we gather feedback for the next milestone.</p>
             <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
                 <div class="border border-blue-100 bg-blue-50 rounded-2xl p-8 shadow-sm">
-                    <h3 class="text-2xl font-semibold text-blue-900 mb-3">Orbas AI 2025.2</h3>
+                    <h3 class="text-2xl font-semibold text-blue-900 mb-3">Orbas AI &mdash; Alpha 1</h3>
                     <ul class="space-y-3 text-blue-900 leading-relaxed">
-                        <li>Introduced governance tooling for model lineage, bias testing and approval workflows.</li>
-                        <li>Expanded API catalogue with secure automation connectors for enterprise systems.</li>
-                        <li>Enhanced energy usage telemetry supporting our <a href="/esg-csr" class="text-orbas-dark-blue underline">ESG roadmap</a>.</li>
+                        <li>Core workflow builder live with two automation templates focused on document summarisation and service-ticket triage.</li>
+                        <li>Lightweight usage dashboards so early adopters can see volume and success rates during testing.</li>
+                        <li>Weekly feedback clinics scheduled with design partners to prioritise the Alpha 2 backlog.</li>
                     </ul>
                 </div>
                 <div class="border border-green-100 bg-green-50 rounded-2xl p-8 shadow-sm">
-                    <h3 class="text-2xl font-semibold text-green-900 mb-3">Orbas Freelance 2025.1</h3>
+                    <h3 class="text-2xl font-semibold text-green-900 mb-3">Orbas Freelance &mdash; Alpha 1</h3>
                     <ul class="space-y-3 text-green-900 leading-relaxed">
-                        <li>Launched verified profiles and background screening to strengthen trust &amp; safety.</li>
-                        <li>Rolled out milestone-based invoicing and instant payouts in partnership with our payments providers.</li>
-                        <li>Released inclusive project templates aligned with our <a href="/equality-diversity" class="text-orbas-dark-blue underline">Equality &amp; Diversity commitments</a>.</li>
+                        <li>Closed pilot marketplace with verified freelancers across data, automation and product disciplines.</li>
+                        <li>Simple milestone tracking and manual invoicing to validate the engagement model before automation.</li>
+                        <li>Early trust &amp; safety checklist launched to guide customers through onboarding responsibilities.</li>
                     </ul>
                 </div>
                 <div class="border border-purple-100 bg-purple-50 rounded-2xl p-8 shadow-sm">
-                    <h3 class="text-2xl font-semibold text-purple-900 mb-3">Orbas Learn 2025.2</h3>
+                    <h3 class="text-2xl font-semibold text-purple-900 mb-3">Orbas Learn &mdash; Alpha 1</h3>
                     <ul class="space-y-3 text-purple-900 leading-relaxed">
-                        <li>Added immersive AI labs and certifications in partnership with global universities.</li>
-                        <li>Improved accessibility tooling with captioning, transcripts and inclusive design updates.</li>
-                        <li>Expanded scholarship programmes highlighted on our <a href="/impact" class="text-orbas-dark-blue underline">Impact</a> page.</li>
+                        <li>Initial catalogue of eight self-paced modules covering automation fundamentals and prompt design.</li>
+                        <li>Instructor-led labs delivered in partnership with local training partners in London and Manchester.</li>
+                        <li>Progress tracking MVP released to capture completion data from the first cohort.</li>
                     </ul>
                 </div>
                 <div class="border border-orange-100 bg-orange-50 rounded-2xl p-8 shadow-sm">
-                    <h3 class="text-2xl font-semibold text-orange-800 mb-3">Orbas Services 2025.1</h3>
+                    <h3 class="text-2xl font-semibold text-orange-800 mb-3">Orbas Services &mdash; Alpha 1</h3>
                     <ul class="space-y-3 text-orange-800 leading-relaxed">
-                        <li>Launched 24/7 managed automation desk with guaranteed SLA tiers.</li>
-                        <li>Introduced delivery playbooks for regulated industries with enhanced compliance checkpoints.</li>
-                        <li>Published our updated <a href="/trust-safety-security" class="text-orbas-dark-blue underline">Trust, Safety &amp; Security statement</a>.</li>
+                        <li>Delivery playbooks drafted for three founding clients focused on automation readiness assessments.</li>
+                        <li>Embedded service desk hours to monitor live deployments and document improvement actions.</li>
+                        <li>Shared retrospectives across functions to align managed services with platform roadmaps.</li>
                     </ul>
                 </div>
             </div>
@@ -91,19 +92,19 @@
             <h2 class="text-3xl font-bold text-gray-900 mb-6">Release Timeline</h2>
             <div class="space-y-8">
                 <div class="border-l-4 border-orbas-blue pl-6">
-                    <p class="text-sm uppercase tracking-widest text-gray-500">June 2025</p>
-                    <h3 class="text-2xl font-semibold text-gray-900">Unified Governance Release</h3>
-                    <p class="text-gray-700 leading-relaxed">Shipped consolidated policy updates covering ESG, trust &amp; safety and modern slavery obligations.</p>
+                    <p class="text-sm uppercase tracking-widest text-gray-500">13 September 2025</p>
+                    <h3 class="text-2xl font-semibold text-gray-900">Alpha 1 Launch</h3>
+                    <p class="text-gray-700 leading-relaxed">Coordinated release of Orbas AI, Orbas Freelance, Orbas Learn and Orbas Services into live customer pilots. Feedback cycles are underway through Q4 2025.</p>
                 </div>
                 <div class="border-l-4 border-orbas-green pl-6">
-                    <p class="text-sm uppercase tracking-widest text-gray-500">April 2025</p>
-                    <h3 class="text-2xl font-semibold text-gray-900">Talent Experience Enhancements</h3>
-                    <p class="text-gray-700 leading-relaxed">Improved onboarding, verification and wellbeing support for our global freelance network.</p>
+                    <p class="text-sm uppercase tracking-widest text-gray-500">November 2025</p>
+                    <h3 class="text-2xl font-semibold text-gray-900">Alpha 1 Updates</h3>
+                    <p class="text-gray-700 leading-relaxed">Planned quality and usability updates based on pilot findings, including billing workflows and expanded automation templates.</p>
                 </div>
                 <div class="border-l-4 border-orbas-purple pl-6">
-                    <p class="text-sm uppercase tracking-widest text-gray-500">February 2025</p>
-                    <h3 class="text-2xl font-semibold text-gray-900">Learning Expansion</h3>
-                    <p class="text-gray-700 leading-relaxed">Released new leadership and AI ethics modules plus reporting dashboards for enterprise cohorts.</p>
+                    <p class="text-sm uppercase tracking-widest text-gray-500">March 2026</p>
+                    <h3 class="text-2xl font-semibold text-gray-900">Beta Readiness Review</h3>
+                    <p class="text-gray-700 leading-relaxed">Six-month impact review and go/no-go decision for opening wider beta access. Metrics will be published here once validated.</p>
                 </div>
             </div>
         </section>
@@ -112,19 +113,19 @@
             <h2 class="text-3xl font-bold text-gray-900 mb-6">Platform Roadmap</h2>
             <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
                 <div class="border border-blue-100 bg-blue-50 rounded-2xl p-8 shadow-sm">
-                    <h3 class="text-2xl font-semibold text-blue-900 mb-3">Upcoming in H2 2025</h3>
+                    <h3 class="text-2xl font-semibold text-blue-900 mb-3">Next 90 Days</h3>
                     <ul class="space-y-3 text-blue-900 leading-relaxed">
-                        <li>Carbon-aware workload routing and sustainability metrics surfaced in Orbas AI dashboards.</li>
-                        <li>Expanded integrations for automation co-pilots and governance reporting.</li>
-                        <li>Marketplace extensions enabling partners to distribute AI accelerators.</li>
+                        <li>Stabilise core infrastructure, monitoring and support workflows across all four platforms.</li>
+                        <li>Document pilot learnings and publish structured FAQs for customers participating in Alpha testing.</li>
+                        <li>Define acceptance criteria for Beta with input from security, compliance and customer success leads.</li>
                     </ul>
                 </div>
                 <div class="border border-green-100 bg-green-50 rounded-2xl p-8 shadow-sm">
-                    <h3 class="text-2xl font-semibold text-green-900 mb-3">Talent &amp; Learning Priorities</h3>
+                    <h3 class="text-2xl font-semibold text-green-900 mb-3">Looking Ahead</h3>
                     <ul class="space-y-3 text-green-900 leading-relaxed">
-                        <li>Launch of the Orbas Fellowship, linking top freelancers to strategic transformation projects.</li>
-                        <li>Enhanced wellbeing toolkit aligned with our <a href="/company-culture" class="text-orbas-dark-blue underline">culture principles</a>.</li>
-                        <li>Expanded community challenges in partnership with non-profits featured on our <a href="/impact" class="text-orbas-dark-blue underline">Impact</a> hub.</li>
+                        <li>Introduce lightweight integrations with finance and HR systems to remove manual effort.</li>
+                        <li>Establish shared analytics foundations to support ESG and impact reporting in 2026.</li>
+                        <li>Prepare customer onboarding guides aligned with our <a href="/company-culture" class="text-orbas-dark-blue underline">culture principles</a> and service standards.</li>
                     </ul>
                 </div>
             </div>
@@ -144,7 +145,7 @@
             <h2 class="text-3xl font-bold text-gray-900 mb-4">Stay Updated</h2>
             <p class="text-gray-700 text-lg leading-relaxed mb-4">Subscribe for quarterly release briefings, roadmap previews and policy updates.</p>
             <div class="flex flex-col sm:flex-row justify-center gap-4">
-                <a href="mailto:releases@orbas.io" class="inline-flex items-center justify-center px-6 py-3 bg-orbas-dark-blue text-white font-semibold rounded-lg shadow hover:bg-blue-800 transition-colors">Email Release Management</a>
+                <a href="mailto:support@orbas.io?subject=Release%20Notes" class="inline-flex items-center justify-center px-6 py-3 bg-orbas-dark-blue text-white font-semibold rounded-lg shadow hover:bg-blue-800 transition-colors">Email Release Management</a>
                 <a href="/impact" class="inline-flex items-center justify-center px-6 py-3 bg-white border border-gray-300 text-gray-900 font-semibold rounded-lg shadow hover:border-orbas-dark-blue hover:text-orbas-dark-blue transition-colors">View Impact Centre</a>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- refresh the release notes to focus on the 13 September 2025 Alpha 1 launches and realistic near-term roadmap
- align the impact page with six-month data collection, grounded initiatives, and a clear March 2026 update cadence
- clarify the careers and culture pages with current hiring status, pragmatic operating practices, and the central support contact

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d04ab9a6788320a3ad3c552c2f1155