### PR TITLE
Strengthen global orb messaging and SEO metadata

### DIFF
--- a/OrbusLanding/footer.html
+++ b/OrbusLanding/footer.html
@@ -3,7 +3,7 @@
         <div class="grid gap-12 lg:grid-cols-4">
             <div class="space-y-6 lg:col-span-2">
                 <a href="/" class="inline-flex items-center">
-                    <img src="https://i.ibb.co/TDdxJfY/craiyon-040322-image.png" alt="Orbas Agency" class="h-14 w-auto drop-shadow-2xl">
+                    <img src="https://i.ibb.co/TDdxJfYJ/craiyon-040322-image.png" alt="Orbas Agency" class="h-14 w-auto drop-shadow-2xl">
                 </a>
                 <p class="text-gray-600 leading-relaxed text-base">
                     Orbas Agency pairs award-winning product craft with battle-tested conversion strategy. From positioning to launch operations, every engagement is designed to compound pipeline growth.
@@ -13,19 +13,15 @@
                         <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M20 4H4a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2zm0 4-8 5-8-5V6l8 5 8-5v2z"/></svg>
                         agency@orbas.io
                     </a>
-                    <a href="https://www.linkedin.com/company/orbas-global1/" class="hover:text-orbas-blue transition-colors inline-flex items-center gap-2" aria-label="LinkedIn">
-                        <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.026-3.037-1.851-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.352V9h3.414v1.561h.049c.476-.9 1.637-1.849 3.372-1.849 3.605 0 4.27 2.371 4.275 5.455v6.285zM5.337 7.433a2.062 2.062 0 1 1 0-4.124 2.062 2.062 0 0 1 0 4.124zm1.777 13.019H3.56V9h3.554v11.452z"/></svg>
-                        LinkedIn
-                    </a>
                 </div>
             </div>
             <div class="space-y-4">
                 <h4 class="text-sm font-semibold uppercase tracking-[0.2em] text-gray-500">What we deliver</h4>
                 <ul class="space-y-2 text-gray-600 text-sm">
-                    <li><a href="/#services" class="hover:text-orbas-blue transition-colors">Product positioning & strategy</a></li>
+                    <li><a href="/#services" class="hover:text-orbas-blue transition-colors">Consultation, discovery & strategic planning</a></li>
                     <li><a href="/#services" class="hover:text-orbas-blue transition-colors">Conversion-optimised experience design</a></li>
-                    <li><a href="/#services" class="hover:text-orbas-blue transition-colors">Full-stack development & automation</a></li>
-                    <li><a href="/#services" class="hover:text-orbas-blue transition-colors">SEO, funnels & growth enablement</a></li>
+                    <li><a href="/#services" class="hover:text-orbas-blue transition-colors">Global web development, AI & automation</a></li>
+                    <li><a href="/#services" class="hover:text-orbas-blue transition-colors">SEO, blockchain products & growth enablement</a></li>
                 </ul>
             </div>
             <div class="space-y-4">

--- a/OrbusLanding/header.html
+++ b/OrbusLanding/header.html
@@ -3,11 +3,12 @@
         <div class="flex justify-between items-center h-16">
             <div class="flex items-center">
                 <a href="/" class="flex items-center">
-                    <img src="https://i.ibb.co/TDdxJfY/craiyon-040322-image.png" alt="Orbas Agency logo" class="h-12 w-auto drop-shadow-lg">
+                    <img src="https://i.ibb.co/TDdxJfYJ/craiyon-040322-image.png" alt="Orbas Agency logo" class="h-12 w-auto drop-shadow-lg">
                 </a>
             </div>
             <nav class="hidden md:flex space-x-8 text-sm font-semibold">
                 <a href="/#services" class="text-gray-700 hover:text-orbas-blue transition-colors">Services</a>
+                <a href="/#expertise" class="text-gray-700 hover:text-orbas-blue transition-colors">Expertise</a>
                 <a href="/#process" class="text-gray-700 hover:text-orbas-blue transition-colors">Process</a>
                 <a href="/#pricing" class="text-gray-700 hover:text-orbas-blue transition-colors">Pricing</a>
                 <a href="/#careers" class="text-gray-700 hover:text-orbas-blue transition-colors">Careers</a>
@@ -30,6 +31,7 @@
 <div id="mobile-menu" class="md:hidden hidden fixed top-16 left-0 right-0 z-40 px-6 py-6 bg-white/95 backdrop-blur shadow-xl border-b border-gray-200 rounded-b-xl">
     <nav class="space-y-4 text-center text-lg font-medium">
         <a href="/#services" class="block text-gray-700 hover:text-orbas-blue">Services</a>
+        <a href="/#expertise" class="block text-gray-700 hover:text-orbas-blue">Expertise</a>
         <a href="/#process" class="block text-gray-700 hover:text-orbas-blue">Process</a>
         <a href="/#pricing" class="block text-gray-700 hover:text-orbas-blue">Pricing</a>
         <a href="/#careers" class="block text-gray-700 hover:text-orbas-blue">Careers</a>

--- a/OrbusLanding/index.html
+++ b/OrbusLanding/index.html
@@ -4,18 +4,28 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Orbas Agency | Conversion-First Digital Product Partner</title>
-    <meta name="description" content="Orbas Agency is the London-based digital product studio trusted for conversion-first websites, apps, automation and SEO. Launch faster with pricing that scales with you.">
-    <meta name="keywords" content="Orbas Agency, conversion focused web design, London digital product studio, SaaS website agency, automation agency, SEO, CRO, pricing">
+    <meta name="description" content="Orbas Agency is the London-founded global studio for conversion-first web development, automation, AI, blockchain, design, web apps, consultation and strategic planning services.">
+    <meta name="keywords" content="Orbas Agency, global web development, automation agency, AI product studio, blockchain development, digital strategy, web app design, consultation, planning services, SEO, CRO">
     <meta name="robots" content="index, follow">
+    <meta name="author" content="Orbas Agency">
+    <meta name="theme-color" content="#0b1f4d">
     <meta property="og:title" content="Orbas Agency | Elite Digital Product & Automation Partner">
-    <meta property="og:description" content="Launch faster with Orbas Agency. Premium strategy, design, development and automation with concierge-level care.">
+    <meta property="og:description" content="Launch faster with Orbas Agency. Global experts in strategy, design, development, automation and AI delivering revenue-focused launches.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://orbas.agency/">
-    <meta property="og:image" content="https://i.ibb.co/TDdxJfY/craiyon-040322-image.png">
+    <meta property="og:image" content="https://i.ibb.co/TDdxJfYJ/craiyon-040322-image.png">
+    <meta property="og:image:alt" content="Orbas Agency logo representing a global delivery network">
+    <meta property="og:locale" content="en_GB">
+    <meta property="og:site_name" content="Orbas Agency">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Orbas Agency | Global Digital Product & Automation Partner">
+    <meta name="twitter:description" content="Global development, automation, AI, design, web app, consultation and planning services engineered for conversions.">
+    <meta name="twitter:image" content="https://i.ibb.co/TDdxJfYJ/craiyon-040322-image.png">
+    <link rel="canonical" href="https://orbas.agency/">
 
     <!-- Favicon -->
-    <link rel="icon" type="image/png" href="https://i.ibb.co/TDdxJfY/craiyon-040322-image.png">
-    <link rel="alternate icon" href="https://i.ibb.co/TDdxJfY/craiyon-040322-image.png">
+    <link rel="icon" type="image/png" href="https://i.ibb.co/8VSNKZc/IMG-2754.png">
+    <link rel="alternate icon" href="https://i.ibb.co/8VSNKZc/IMG-2754.png">
 
     <!-- Google Fonts - Poppins -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -44,6 +54,37 @@
             }
         }
     </script>
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "ProfessionalService",
+        "name": "Orbas Agency",
+        "url": "https://orbas.agency/",
+        "description": "Orbas Agency is a global studio delivering conversion-first web development, automation, AI, blockchain, design, web app, consultation and planning services.",
+        "logo": "https://i.ibb.co/TDdxJfYJ/craiyon-040322-image.png",
+        "areaServed": "Worldwide",
+        "email": "agency@orbas.io",
+        "sameAs": [
+            "https://www.instagram.com/orbasagency",
+            "https://twitter.com/orbasagency"
+        ],
+        "address": {
+            "@type": "PostalAddress",
+            "addressLocality": "London",
+            "addressCountry": "GB"
+        },
+        "serviceType": [
+            "Web development",
+            "Automation",
+            "Artificial intelligence",
+            "Blockchain",
+            "Design",
+            "Web applications",
+            "Consultation",
+            "Strategic planning"
+        ]
+    }
+    </script>
 </head>
 <body class="bg-white text-gray-900 font-poppins antialiased">
     <div id="header"></div>
@@ -60,10 +101,10 @@
                     Conversion partners for ambitious launches
                 </div>
                 <h1 class="text-4xl sm:text-5xl lg:text-6xl font-bold leading-tight mb-6">
-                    Conversion-First Launches
+                    Global Conversion-First Launches
                 </h1>
                 <p class="text-lg sm:text-xl text-blue-100 leading-relaxed mb-8">
-                    London-founded product studio delivering SEO-rich, automation-ready experiences that turn traffic into paying customers. Our founder-led team has already driven up to 43% lift in funnel conversions during the freelancing era—now we scale that impact with you.
+                    London-founded and globally delivered, we craft SEO-rich, automation-ready experiences that turn traffic into paying customers. Our founder-led team has already driven up to 43% lift in funnel conversions during the freelancing era—now we scale that impact with you across every market you enter.
                 </p>
                 <div class="flex flex-col sm:flex-row gap-4">
                     <a href="#contact" class="inline-flex items-center justify-center px-8 py-4 rounded-xl font-semibold bg-white text-orbas-dark-blue shadow-lg hover:shadow-xl transition transform hover:-translate-y-0.5">
@@ -82,23 +123,24 @@
                 <div class="mt-10 space-y-4 text-blue-100/90">
                     <div class="inline-flex items-center gap-3 bg-white/10 border border-white/20 rounded-2xl px-5 py-3 backdrop-blur">
                         <span class="inline-flex h-8 w-8 items-center justify-center rounded-full bg-white/20 text-white font-semibold">43%</span>
-                        <p class="text-sm sm:text-base">Freelance-proven uplift in qualified lead conversions, now available on agency scale.</p>
+                        <p class="text-sm sm:text-base">Freelance-proven uplift in qualified lead conversions, now available on global agency scale.</p>
                     </div>
                     <ul class="space-y-3 text-sm sm:text-base">
                         <li class="flex items-start gap-3"><span class="mt-1 h-2 w-2 rounded-full bg-white"></span>Strategy, UX, engineering and automation orchestrated under one growth playbook.</li>
                         <li class="flex items-start gap-3"><span class="mt-1 h-2 w-2 rounded-full bg-white"></span>SEO architecture and CRO frameworks embedded from day zero.</li>
                         <li class="flex items-start gap-3"><span class="mt-1 h-2 w-2 rounded-full bg-white"></span>Real-time collaboration with founder access and senior specialists on every sprint.</li>
+                        <li class="flex items-start gap-3"><span class="mt-1 h-2 w-2 rounded-full bg-white"></span>Delivery pods operating across time zones for responsive launches and support.</li>
                     </ul>
                 </div>
             </div>
             <div class="relative">
                 <div class="relative overflow-hidden rounded-3xl shadow-2xl border border-white/10">
-                    <img src="attached_assets/ai_1752430264374.jpg" alt="Creative team collaborating" class="w-full h-[520px] object-cover">
+                    <img src="attached_assets/ai_1752430264374.jpg" alt="Creative team collaborating" class="w-full h-[520px] object-cover" loading="lazy" decoding="async">
                     <div class="absolute inset-0 bg-gradient-to-t from-orbas-dark-blue/70 via-transparent to-transparent"></div>
                     <div class="absolute bottom-6 left-6 right-6">
                         <div class="bg-white/10 backdrop-blur-md rounded-2xl p-5 border border-white/20">
                             <h3 class="text-lg font-semibold">Full-stack launch partners</h3>
-                            <p class="text-sm text-blue-100/80">Product strategy, UX, engineering, AI automations and growth enablement in one team.</p>
+                            <p class="text-sm text-blue-100/80">Product strategy, UX, engineering, AI automations and growth enablement in one global team.</p>
                         </div>
                     </div>
                 </div>
@@ -157,10 +199,15 @@
         <div class="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(96,165,250,0.25),_transparent_60%)]"></div>
         <div class="relative max-w-7xl mx-auto grid grid-cols-1 lg:grid-cols-2 gap-16 items-center">
             <div class="order-2 lg:order-1">
-                <span class="inline-flex items-center px-4 py-2 rounded-full text-sm font-medium bg-white/10 border border-white/20 mb-6">🪐 Precision delivery network</span>
-                <h2 class="text-3xl sm:text-4xl font-bold mb-6">A connected operating system for every launch</h2>
-                <p class="text-lg text-blue-100/90 leading-relaxed mb-4">The Orbas Command Orb keeps strategists, designers, engineers and automation specialists aligned in real time. Expect faster decisions, richer insights and releases that stay ahead of market shifts.</p>
-                <p class="text-lg text-blue-100/90 leading-relaxed">You’ll approve in a dedicated workspace with AI-assisted QA, SEO scorecards and proactive conversion experiments queued up for the next sprint.</p>
+                <span class="inline-flex items-center px-4 py-2 rounded-full text-sm font-medium bg-white/10 border border-white/20 mb-6">🪐 Global delivery orbit</span>
+                <h2 class="text-3xl sm:text-4xl font-bold mb-6">A globe-inspired system guiding every engagement</h2>
+                <p class="text-lg text-blue-100/90 leading-relaxed mb-4">The signature Orbas orb is a design tribute to the worldwide network that surrounds each project. It visualises how our strategists, designers, developers and automation leads stay synchronised across time zones.</p>
+                <p class="text-lg text-blue-100/90 leading-relaxed mb-6">From discovery to launch, we layer global development talent with automation engineers, AI specialists, product designers, web app builders, consultants and planning leads to keep every milestone accountable.</p>
+                <ul class="space-y-3 text-blue-100/80 text-sm sm:text-base bg-white/5 border border-white/10 rounded-2xl px-6 py-5 backdrop-blur-sm">
+                    <li class="flex items-start gap-3"><span class="mt-1 h-2 w-2 rounded-full bg-white"></span>Follow-the-sun collaboration covering strategy workshops, design sprints and engineering stand-ups.</li>
+                    <li class="flex items-start gap-3"><span class="mt-1 h-2 w-2 rounded-full bg-white"></span>Automation and AI operations embedded alongside web development, blockchain builds and product QA.</li>
+                    <li class="flex items-start gap-3"><span class="mt-1 h-2 w-2 rounded-full bg-white"></span>Consultation and planning services that translate your roadmap into measurable releases and conversion experiments.</li>
+                </ul>
             </div>
             <div class="order-1 lg:order-2 relative flex justify-center lg:justify-end">
                 <div class="relative w-full max-w-[420px] aspect-square mx-auto">
@@ -169,10 +216,81 @@
                     <canvas id="innovation-orb-canvas" class="relative z-10 block w-full h-full" aria-hidden="true"></canvas>
                     <div class="absolute bottom-6 left-1/2 z-20 w-60 -translate-x-1/2">
                         <div class="bg-white/10 border border-white/10 backdrop-blur-lg rounded-2xl px-6 py-4 shadow-xl text-center">
-                            <p class="text-sm font-semibold uppercase tracking-wide text-blue-100">Orbas Agency Command</p>
-                            <p class="text-xs text-blue-100/80 mt-1">Live metrics, sprint updates and automation triggers in one view</p>
+                            <p class="text-sm font-semibold uppercase tracking-wide text-blue-100">Worldwide delivery map</p>
+                            <p class="text-xs text-blue-100/80 mt-1">Strategy, web dev, automation, AI and planning connected across continents</p>
                         </div>
                     </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Expertise Section -->
+    <section id="expertise" class="py-24 px-4 sm:px-6 lg:px-8 bg-white">
+        <div class="max-w-6xl mx-auto">
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-12 items-start mb-16">
+                <div>
+                    <span class="inline-flex items-center px-4 py-2 rounded-full text-sm font-medium bg-orbas-blue/10 text-orbas-blue border border-orbas-blue/20 mb-4">🔭 Deeper than delivery</span>
+                    <h2 class="text-3xl sm:text-4xl font-bold text-gray-900 mb-4">Building the modern revenue engine</h2>
+                    <p class="text-lg text-gray-600">Our squads don’t stop at beautiful interfaces—we architect resilient systems that compound growth. From high-performing marketing sites to blockchain-backed digital products, we connect strategy, engineering and automation so your team can move faster with less overhead.</p>
+                </div>
+                <div class="bg-gradient-to-br from-orbas-blue/10 via-white to-blue-50 border border-blue-100 rounded-3xl p-8 shadow-xl">
+                    <h3 class="text-xl font-semibold text-gray-900 mb-3">What you can expect partnering with Orbas Agency</h3>
+                    <ul class="space-y-3 text-gray-600 text-sm">
+                        <li class="flex items-start gap-3"><span class="mt-1 h-2 w-2 rounded-full bg-orbas-blue"></span>Founder-level involvement on every engagement with clear roadmaps, velocity targets and measurable ROI triggers.</li>
+                        <li class="flex items-start gap-3"><span class="mt-1 h-2 w-2 rounded-full bg-orbas-blue"></span>Cross-discipline collaboration that pairs strategists, engineers, automation leads and growth operators from day one.</li>
+                        <li class="flex items-start gap-3"><span class="mt-1 h-2 w-2 rounded-full bg-orbas-blue"></span>Transparent delivery with weekly demos, async updates and command-centre dashboards tailored for your leadership team.</li>
+                    </ul>
+                </div>
+            </div>
+            <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-8">
+                <div class="p-8 rounded-2xl bg-gradient-to-br from-white via-white to-blue-50 border border-blue-100 shadow-lg hover:-translate-y-1 hover:shadow-xl transition">
+                    <div class="flex items-center justify-between mb-4">
+                        <h3 class="text-xl font-semibold text-gray-900">Web Development</h3>
+                        <span class="text-sm font-medium text-orbas-blue">Speed & SEO</span>
+                    </div>
+                    <p class="text-sm text-gray-600 leading-relaxed">We ship conversion-first marketing sites, web apps and client portals with strict performance budgets, global CDNs and accessibility baked in.</p>
+                    <ul class="mt-5 space-y-2 text-sm text-gray-600">
+                        <li class="flex"><span class="text-orbas-blue mr-2">◆</span>Next.js, Webflow, Framer & custom stacks</li>
+                        <li class="flex"><span class="text-orbas-blue mr-2">◆</span>Internationalisation & localisation workflows</li>
+                        <li class="flex"><span class="text-orbas-blue mr-2">◆</span>Analytics, CRO experiments & QA automation</li>
+                    </ul>
+                </div>
+                <div class="p-8 rounded-2xl bg-gradient-to-br from-white via-white to-blue-50 border border-blue-100 shadow-lg hover:-translate-y-1 hover:shadow-xl transition">
+                    <div class="flex items-center justify-between mb-4">
+                        <h3 class="text-xl font-semibold text-gray-900">Blockchain Systems</h3>
+                        <span class="text-sm font-medium text-orbas-blue">Secure & scalable</span>
+                    </div>
+                    <p class="text-sm text-gray-600 leading-relaxed">Whether token-gated communities or on-chain data products, our engineers design compliant, human-friendly blockchain experiences.</p>
+                    <ul class="mt-5 space-y-2 text-sm text-gray-600">
+                        <li class="flex"><span class="text-orbas-blue mr-2">◆</span>dApp UX audits & product-market fit validation</li>
+                        <li class="flex"><span class="text-orbas-blue mr-2">◆</span>Smart contract integrations & security reviews</li>
+                        <li class="flex"><span class="text-orbas-blue mr-2">◆</span>Wallet onboarding, custody & analytics dashboards</li>
+                    </ul>
+                </div>
+                <div class="p-8 rounded-2xl bg-gradient-to-br from-white via-white to-blue-50 border border-blue-100 shadow-lg hover:-translate-y-1 hover:shadow-xl transition">
+                    <div class="flex items-center justify-between mb-4">
+                        <h3 class="text-xl font-semibold text-gray-900">Automation Ops</h3>
+                        <span class="text-sm font-medium text-orbas-blue">AI-native</span>
+                    </div>
+                    <p class="text-sm text-gray-600 leading-relaxed">We orchestrate AI co-pilots, CRM workflows and data pipelines that eliminate manual busywork and surface real-time revenue signals.</p>
+                    <ul class="mt-5 space-y-2 text-sm text-gray-600">
+                        <li class="flex"><span class="text-orbas-blue mr-2">◆</span>HubSpot, Salesforce, Zapier & n8n ecosystems</li>
+                        <li class="flex"><span class="text-orbas-blue mr-2">◆</span>LLM-enabled playbooks & agentic automations</li>
+                        <li class="flex"><span class="text-orbas-blue mr-2">◆</span>Data hygiene, enrichment & alerting frameworks</li>
+                    </ul>
+                </div>
+                <div class="p-8 rounded-2xl bg-gradient-to-br from-white via-white to-blue-50 border border-blue-100 shadow-lg hover:-translate-y-1 hover:shadow-xl transition">
+                    <div class="flex items-center justify-between mb-4">
+                        <h3 class="text-xl font-semibold text-gray-900">Growth Strategy</h3>
+                        <span class="text-sm font-medium text-orbas-blue">Always-on</span>
+                    </div>
+                    <p class="text-sm text-gray-600 leading-relaxed">Strategy isn’t a deck—it's an operating system. We connect positioning, campaigns and analytics to keep your launch marching toward revenue.</p>
+                    <ul class="mt-5 space-y-2 text-sm text-gray-600">
+                        <li class="flex"><span class="text-orbas-blue mr-2">◆</span>Audience research, narrative design & GTM sequencing</li>
+                        <li class="flex"><span class="text-orbas-blue mr-2">◆</span>Pricing & packaging experiments with executive war rooms</li>
+                        <li class="flex"><span class="text-orbas-blue mr-2">◆</span>North-star metrics, OKRs & investor-ready reporting</li>
+                    </ul>
                 </div>
             </div>
         </div>
@@ -233,14 +351,22 @@
             </div>
             <div class="relative">
                 <div class="p-10 bg-gradient-to-br from-orbas-blue to-sky-500 rounded-3xl text-white shadow-2xl">
-                    <svg class="w-12 h-12 mb-6 text-white/80" fill="currentColor" viewBox="0 0 24 24">
-                        <path d="M7.17 6A5.001 5.001 0 0 1 12 1a5 5 0 0 1 4.83 6.5l-.34 1A4 4 0 0 1 20 12v2a4 4 0 0 1-4 4h-4v-5a5 5 0 0 0-4.83-5.5l.34-1zM3 13a4 4 0 0 1 4-4h1a4 4 0 0 1 4 4v5H7a4 4 0 0 1-4-4v-1z" />
-                    </svg>
-                    <p class="text-lg leading-relaxed">“Orbas Agency gave us a product vision and a working platform in record time. Their team behave like co-founders—proactive, decisive and obsessed with the result.”</p>
-                    <div class="mt-6">
-                        <p class="font-semibold">Chloe Mercer</p>
-                        <p class="text-sm text-blue-100/90">Chief Product Officer, Latticewave</p>
-                    </div>
+                    <h3 class="text-2xl font-semibold mb-4">Conversion partnership commitments</h3>
+                    <p class="text-blue-100/90 leading-relaxed mb-6">We co-create every roadmap with the same principles that helped our founder deliver double-digit conversion lifts as a solo operator. When we partner with you, here’s what to expect:</p>
+                    <ul class="space-y-4 text-sm sm:text-base">
+                        <li class="flex items-start gap-3">
+                            <span class="mt-1 h-2 w-2 rounded-full bg-white"></span>
+                            North-star metrics defined up front, with weekly instrumentation reviews so every release stays accountable to revenue.
+                        </li>
+                        <li class="flex items-start gap-3">
+                            <span class="mt-1 h-2 w-2 rounded-full bg-white"></span>
+                            Cross-functional pods that include strategy, UX, engineering and automation specialists from day one.
+                        </li>
+                        <li class="flex items-start gap-3">
+                            <span class="mt-1 h-2 w-2 rounded-full bg-white"></span>
+                            Decision logs and sprint summaries delivered in plain language, keeping executives aligned without relying on testimonials.
+                        </li>
+                    </ul>
                 </div>
             </div>
         </div>
@@ -359,7 +485,7 @@
                 <p id="form-message" class="hidden text-center text-sm text-blue-100 mt-4"></p>
             </div>
             <div class="mt-10 text-center text-sm text-blue-100/80 space-y-2">
-                <p>Prefer a direct chat? Message us on LinkedIn and we’ll respond within minutes.</p>
+                <p>Prefer a direct chat? Email us or request a WhatsApp introduction in your message and we’ll respond within minutes.</p>
                 <p>Email <a href="mailto:agency@orbas.io" class="underline">agency@orbas.io</a> · Press <a href="mailto:press@orbas.io" class="underline">press@orbas.io</a></p>
             </div>
         </div>

--- a/OrbusLanding/privacy/index.html
+++ b/OrbusLanding/privacy/index.html
@@ -4,12 +4,26 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Privacy Policy | Orbas Agency</title>
-    <meta name="description" content="Read how Orbas Agency protects personal data across our digital services, automations and support operations in line with UK GDPR.">
+    <meta name="description" content="Read how Orbas Agency protects personal data across global web development, automation, AI and consulting engagements in full alignment with UK GDPR.">
     <meta name="robots" content="index, follow">
+    <meta name="author" content="Orbas Agency">
+    <meta name="theme-color" content="#0b1f4d">
+    <meta property="og:title" content="Privacy Policy | Orbas Agency">
+    <meta property="og:description" content="Discover how Orbas Agency safeguards data for global development, automation, AI, design and planning engagements.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://orbas.agency/privacy">
+    <meta property="og:image" content="https://i.ibb.co/TDdxJfYJ/craiyon-040322-image.png">
+    <meta property="og:image:alt" content="Orbas Agency globe-inspired logo">
+    <meta property="og:site_name" content="Orbas Agency">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Privacy Policy | Orbas Agency">
+    <meta name="twitter:description" content="How Orbas Agency manages privacy for global web development, automation, AI and consulting programs.">
+    <meta name="twitter:image" content="https://i.ibb.co/TDdxJfYJ/craiyon-040322-image.png">
+    <link rel="canonical" href="https://orbas.agency/privacy">
 
     <!-- Favicon -->
-    <link rel="icon" type="image/png" href="https://i.ibb.co/TDdxJfY/craiyon-040322-image.png">
-    <link rel="alternate icon" href="https://i.ibb.co/TDdxJfY/craiyon-040322-image.png">
+    <link rel="icon" type="image/png" href="https://i.ibb.co/8VSNKZc/IMG-2754.png">
+    <link rel="alternate icon" href="https://i.ibb.co/8VSNKZc/IMG-2754.png">
 
     <!-- Google Fonts - Poppins -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -35,6 +49,24 @@
                 }
             }
         }
+    </script>
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "WebPage",
+        "name": "Orbas Agency Privacy Policy",
+        "url": "https://orbas.agency/privacy",
+        "description": "Read how Orbas Agency protects personal data across global web development, automation, AI and consulting engagements in line with UK GDPR.",
+        "publisher": {
+            "@type": "Organization",
+            "name": "Orbas Agency",
+            "url": "https://orbas.agency/",
+            "logo": {
+                "@type": "ImageObject",
+                "url": "https://i.ibb.co/TDdxJfYJ/craiyon-040322-image.png"
+            }
+        }
+    }
     </script>
 </head>
 <body class="bg-white text-gray-900 font-poppins antialiased">


### PR DESCRIPTION
## Summary
- highlight the orb section and hero messaging as a global delivery network with refreshed styling instead of a "command" product reference
- add comprehensive SEO metadata, canonical links, and structured data for the homepage and privacy policy to surface global service offerings
- align the footer service list with consultation, automation, blockchain, and worldwide development capabilities

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e5db798f1c8320b4487bb6b56ca01a